### PR TITLE
Always update existing artifacts on import

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1243,7 +1243,7 @@ async function handleDetailImport() {
         action: 'uploadCollectionData',
         data: dataToUpload,
         dataType: currentDetailDataType,
-        updateExisting: false,
+        updateExisting: currentDetailDataType === 'collection_artifact',
         conflictResolutions: conflictResolutions || undefined
       })
     } else if (currentDetailDataType === 'character_stats') {


### PR DESCRIPTION
## Summary
- Flip `updateExisting` to `true` for artifact imports so re-importing populates Cygames scores on existing rows without needing full sync
- Only affects artifacts; other collection types keep the `false` default