### PR TITLE
Replace next.granblue.team URLs

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -16,8 +16,8 @@ export const ENVIRONMENTS = {
     apiPath: '/v1'
   },
   development: {
-    apiUrl: 'https://next-api.granblue.team',
-    siteUrl: 'https://next.granblue.team',
+    apiUrl: 'https://api.granblue.team',
+    siteUrl: 'https://granblue.team',
     apiPath: '/v1'
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -40,7 +40,7 @@
           </div>
           <div class="auth-footer">
             <span>Don't have an account?</span>
-            <a target="_blank" href="https://next.granblue.team/auth/register">Create one</a>
+            <a target="_blank" href="https://granblue.team/auth/register">Create one</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Swap `next.granblue.team` and `next-api.granblue.team` URLs back to `granblue.team` / `api.granblue.team` after migration

## Test plan
- [ ] Verify login and registration links point to correct domain
- [ ] Verify dev environment API calls hit `api.granblue.team`