### PR TITLE
remove stale next-api host permission

### DIFF
--- a/manifest.template.json
+++ b/manifest.template.json
@@ -12,8 +12,7 @@
   "key": "{{UNIQUE_KEY}}",
   "host_permissions": [
     "https://game.granbluefantasy.jp/*",
-    "https://api.granblue.team/*",
-    "https://next-api.granblue.team/*"
+    "https://api.granblue.team/*"
   ],
   "action": {
     "default_icon": {


### PR DESCRIPTION
Removes the leftover `next-api.granblue.team` host permission from the manifest that was missed in #14.