### PR TITLE
Weapon image _0 fallback in collection views

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -873,9 +873,17 @@ function renderDetailItems(dataType, data) {
       })
     })
 
-    // Hide items when their image fails to load
+    // Hide items when their image fails to load, trying fallback first
     container.querySelectorAll('.selectable img').forEach(img => {
       img.addEventListener('error', () => {
+        // Try fallback: remove element suffix (e.g., _0.jpg -> .jpg) before hiding
+        const fallbackSrc = img.src.replace(/_\d+\.jpg$/, '.jpg')
+        if (img.src !== fallbackSrc && !img.dataset.fallbackAttempted) {
+          img.dataset.fallbackAttempted = 'true'
+          img.src = fallbackSrc
+          return
+        }
+
         const item = img.closest('.selectable')
         if (!item) return
         const index = parseInt(item.dataset.index, 10)


### PR DESCRIPTION
## Summary
- When a weapon image fails to load in collection views, try removing the element suffix (`_0.jpg` → `.jpg`) before hiding the item
- Fixes Class Champion weapons and other element-changeable weapons whose `_0` image doesn't exist on the CDN

## Test plan
- [ ] Load collection with a Class Champion weapon — image shows fallback instead of being hidden