### PR TITLE
Show job skills in party detail

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1624,6 +1624,42 @@ body.light #detailImport {
   display: block;
 }
 
+/* Job Skills List */
+.job-skills-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.job-skill-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.job-skill-item img {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.job-skill-item span {
+  font-size: 13px;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.job-skill-placeholder {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  background: var(--color-bg-darker, #333);
+}
+
 /* Character grid: 5 columns */
 .character-grid {
   display: grid;

--- a/popup.js
+++ b/popup.js
@@ -810,6 +810,31 @@ async function fetchWeaponKeyMap() {
 }
 
 /**
+ * Fetch job skill slugs by name from the API.
+ * Cached in memory for the session.
+ */
+let _jobSkillCache = {}
+async function fetchJobSkillSlugs(names) {
+  const uncached = names.filter(n => !(n in _jobSkillCache))
+  if (uncached.length === 0) {
+    return Object.fromEntries(names.map(n => [n, _jobSkillCache[n] || null]))
+  }
+  try {
+    const apiUrl = await getApiUrl('/job_skills/resolve')
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ names: uncached })
+    })
+    if (response.ok) {
+      const results = await response.json()
+      for (const r of results) _jobSkillCache[r.name] = r.slug
+    }
+  } catch { /* fall through */ }
+  return Object.fromEntries(names.map(n => [n, _jobSkillCache[n] || null]))
+}
+
+/**
  * Render items in detail view
  */
 async function renderDetailItems(dataType, data) {
@@ -818,11 +843,14 @@ async function renderDetailItems(dataType, data) {
   // Party gets special sectioned layout
   if (dataType.startsWith('party_')) {
     const friendSummonName = data?.deck?.pc?.damage_info?.summon_name
-    const [friendSummon, weaponKeyMap] = await Promise.all([
+    const setAction = data?.deck?.pc?.set_action || []
+    const skillNames = setAction.map(s => s.name).filter(Boolean)
+    const [friendSummon, weaponKeyMap, jobSkillSlugs] = await Promise.all([
       searchSummonByName(friendSummonName),
-      fetchWeaponKeyMap()
+      fetchWeaponKeyMap(),
+      skillNames.length > 0 ? fetchJobSkillSlugs(skillNames) : Promise.resolve({})
     ])
-    renderPartyDetail(container, data, { friendSummon, weaponKeyMap })
+    renderPartyDetail(container, data, { friendSummon, weaponKeyMap, jobSkillSlugs })
     return
   }
 

--- a/render-detail.js
+++ b/render-detail.js
@@ -397,6 +397,8 @@ export function renderPartyDetail(container, data, options = {}) {
   const accessoryIds = [pc.familiar_id, pc.shield_id].filter(Boolean)
   const weaponKeyMap = options.weaponKeyMap || null
   const quickSummonId = pc.quick_user_summon_id
+  const setAction = pc.set_action || []
+  const jobSkillSlugs = options.jobSkillSlugs || {}
 
   let html = ''
 
@@ -416,6 +418,20 @@ export function renderPartyDetail(container, data, options = {}) {
             </div>
           `).join('')}
         </div>
+        ${setAction.length > 0 ? `
+          <div class="job-skills-list">
+            ${setAction.map(skill => {
+              const slug = jobSkillSlugs[skill.name]
+              const iconUrl = slug ? getImageUrl(`job-skills/${slug}.png`) : null
+              return `
+                <div class="job-skill-item">
+                  ${iconUrl ? `<img src="${iconUrl}" alt="${skill.name}">` : '<div class="job-skill-placeholder"></div>'}
+                  <span>${skill.name}</span>
+                </div>
+              `
+            }).join('')}
+          </div>
+        ` : ''}
       </div>
     `
   }


### PR DESCRIPTION
## Summary
- Fetch job skill slugs from API via `POST /job_skills/resolve` (with session cache)
- Render equipped skills as a vertical list with icon + name below the job row
- Falls back to a placeholder if a skill slug can't be resolved

## Test plan
- [ ] Capture a team with job skills — verify icons and names appear below the job image
- [ ] Verify skills with no match show placeholder
- [ ] Verify no regressions on teams without skills