### PR TITLE
Add i18n.js to release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           cp background.js granblue-team-extension/
           cp popup.html popup.js popup.css granblue-team-extension/
           cp auth.js cache.js conflict-resolution.js constants.js granblue-team-extension/
-          cp debugger.js dom.js game-data.js mastery.js granblue-team-extension/
+          cp debugger.js dom.js game-data.js i18n.js mastery.js granblue-team-extension/
           cp playlist-picker.js raid-picker.js render-detail.js storage.js sync.js granblue-team-extension/
           cp icon16.png icon48.png icon128.png granblue-team-extension/
           cp -r icons granblue-team-extension/


### PR DESCRIPTION
i18n.js was missing from the explicit file list in the release workflow, so it wasn't being included in the extension zip.