### PR TITLE
Add visibility select and crew share toggle to party import

### DIFF
--- a/background.js
+++ b/background.js
@@ -564,7 +564,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         message.data,
         message.raidId,
         message.playlistIds,
-        message.name
+        message.name,
+        message.visibility,
+        message.shareWithCrew
       ).then(sendResponse)
       return true
 
@@ -888,14 +890,30 @@ async function authenticatedPost(endpoint, body) {
   }
 }
 
-async function uploadPartyData(data, raidId, playlistIds, name) {
+async function uploadPartyData(
+  data,
+  raidId,
+  playlistIds,
+  name,
+  visibility,
+  shareWithCrew
+) {
   const body = { import: data }
   if (raidId) body.raid_id = raidId
   if (playlistIds?.length > 0) body.playlist_ids = playlistIds
   if (name) body.name = name
+  if (visibility) body.visibility = visibility
 
   const result = await authenticatedPost('/import', body)
   if (result.error) return result
+
+  // Share with crew if requested
+  if (shareWithCrew && result.data?.party_id) {
+    await authenticatedPost(
+      `/parties/${result.data.party_id}/shares`,
+      {}
+    ).catch(() => {}) // Don't fail the import if sharing fails
+  }
 
   const siteUrl = await getSiteBaseUrl()
   return {

--- a/i18n.js
+++ b/i18n.js
@@ -283,6 +283,10 @@ const strings = {
   playlist_private: { en: 'Private', ja: 'プライベート' },
   playlist_unlisted: { en: 'Unlisted', ja: '限定公開' },
   playlist_public: { en: 'Public', ja: '公開' },
+  visibility_anyone: { en: 'Anyone', ja: '全体公開' },
+  visibility_unlisted: { en: 'Unlisted', ja: '限定公開' },
+  visibility_private: { en: 'Private', ja: 'プライベート' },
+  share_with_crew: { en: 'Share with crew', ja: 'クルーと共有' },
   playlist_no_playlists: {
     en: 'No playlists yet. Create one!',
     ja: 'プレイリストがまだありません。作成しましょう！'

--- a/i18n.js
+++ b/i18n.js
@@ -286,7 +286,7 @@ const strings = {
   visibility_anyone: { en: 'Anyone', ja: '全体公開' },
   visibility_unlisted: { en: 'Unlisted', ja: '限定公開' },
   visibility_private: { en: 'Private', ja: 'プライベート' },
-  share_with_crew: { en: 'Share with crew', ja: 'クルーと共有' },
+  crew_label: { en: 'Crew', ja: 'クルー' },
   playlist_no_playlists: {
     en: 'No playlists yet. Create one!',
     ja: 'プレイリストがまだありません。作成しましょう！'

--- a/popup.css
+++ b/popup.css
@@ -2645,11 +2645,11 @@ body.light #detailSync {
 }
 
 .crew-share-toggle[data-state='checked'] .crew-share-checkbox {
-  background: #a9a9a9;
+  background: var(--element-button-bg);
 }
 
 .crew-share-toggle[data-state='checked']:hover .crew-share-checkbox {
-  background: #c6c6c6;
+  background: var(--element-button-bg-hover);
 }
 
 .crew-share-toggle[data-state='checked'] .crew-share-check {

--- a/popup.css
+++ b/popup.css
@@ -2509,6 +2509,7 @@ body.light #detailSync {
 .playlist-selector-label {
   flex: 1;
   text-align: left;
+  user-select: none;
 }
 
 /* ==========================================
@@ -2550,6 +2551,7 @@ body.light #detailSync {
 .visibility-selector-label {
   flex: 1;
   text-align: left;
+  user-select: none;
 }
 
 .icon-chevron-down {

--- a/popup.css
+++ b/popup.css
@@ -2621,12 +2621,45 @@ body.light #detailSync {
   background: var(--button-bg-hover);
 }
 
-.crew-share-toggle input[type='checkbox'] {
-  width: 18px;
-  height: 18px;
-  margin: 0;
-  cursor: pointer;
-  accent-color: var(--color-primary, #4a90d9);
+.crew-share-checkbox {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  background: white;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.18s ease-out;
+}
+
+.crew-share-toggle:hover .crew-share-checkbox {
+  background: #fafafa;
+}
+
+.crew-share-check {
+  width: 12px;
+  height: 12px;
+  color: #515151;
+  display: none;
+}
+
+.crew-share-toggle[data-state='checked'] .crew-share-checkbox {
+  background: #a9a9a9;
+}
+
+.crew-share-toggle[data-state='checked']:hover .crew-share-checkbox {
+  background: #c6c6c6;
+}
+
+.crew-share-toggle[data-state='checked'] .crew-share-check {
+  display: block;
+  color: white;
+}
+
+.crew-share-toggle:focus-visible .crew-share-checkbox {
+  border: 2px solid rgba(59, 130, 246, 0.5);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
 
 .crew-share-label {

--- a/popup.css
+++ b/popup.css
@@ -2514,8 +2514,15 @@ body.light #detailSync {
 /* ==========================================
    VISIBILITY SELECTOR (in party detail view)
    ========================================== */
+.visibility-row {
+  display: flex;
+  gap: 8px;
+}
+
 .visibility-selector {
   position: relative;
+  flex: 1;
+  min-width: 0;
 }
 
 .visibility-selector-button {
@@ -2603,7 +2610,6 @@ body.light #detailSync {
   display: flex;
   align-items: center;
   gap: 10px;
-  width: 100%;
   padding: 8px 16px;
   background: var(--color-bg);
   border: none;
@@ -2615,6 +2621,7 @@ body.light #detailSync {
   color: var(--color-text);
   cursor: pointer;
   transition: background var(--transition-fast);
+  white-space: nowrap;
 }
 
 .crew-share-toggle:hover {

--- a/popup.css
+++ b/popup.css
@@ -2512,6 +2512,129 @@ body.light #detailSync {
 }
 
 /* ==========================================
+   VISIBILITY SELECTOR (in party detail view)
+   ========================================== */
+.visibility-selector {
+  position: relative;
+}
+
+.visibility-selector-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 16px;
+  background: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-md);
+  min-height: 50px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.visibility-selector-button:hover {
+  background: var(--button-bg-hover);
+}
+
+.visibility-selector-label {
+  flex: 1;
+  text-align: left;
+}
+
+.icon-chevron-down {
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+
+.visibility-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  background: white;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  padding: 4px;
+  z-index: 100;
+  animation: visibilityFadeIn 0.15s ease-out;
+}
+
+@keyframes visibilityFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.visibility-option {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  user-select: none;
+}
+
+.visibility-option:hover {
+  background: var(--input-bound-bg-hover);
+}
+
+.visibility-option.selected {
+  font-weight: 500;
+}
+
+/* ==========================================
+   CREW SHARE TOGGLE (in party detail view)
+   ========================================== */
+.crew-share-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 16px;
+  background: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-md);
+  min-height: 50px;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.crew-share-toggle:hover {
+  background: var(--button-bg-hover);
+}
+
+.crew-share-toggle input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--color-primary, #4a90d9);
+}
+
+.crew-share-label {
+  flex: 1;
+  text-align: left;
+}
+
+/* ==========================================
    PLAYLIST PICKER VIEW
    ========================================== */
 .playlist-picker-view {

--- a/popup.css
+++ b/popup.css
@@ -2672,6 +2672,7 @@ body.light #detailSync {
 .crew-share-label {
   flex: 1;
   text-align: left;
+  user-select: none;
 }
 
 /* ==========================================

--- a/popup.html
+++ b/popup.html
@@ -444,6 +444,61 @@
               </svg>
             </button>
           </div>
+          <div id="visibilitySelector" class="visibility-selector">
+            <button
+              id="visibilitySelectorButton"
+              class="visibility-selector-button"
+              type="button"
+            >
+              <span
+                id="visibilitySelectorLabel"
+                class="visibility-selector-label"
+                data-i18n="visibility_private"
+                >Private</span
+              >
+              <svg
+                class="icon-chevron-down"
+                viewBox="0 0 14 14"
+                fill="currentColor"
+                width="12"
+                height="12"
+              >
+                <path
+                  d="M2.04309 4.17094C1.6528 4.56138 1.6529 5.19456 2.04309 5.58486L6.28625 9.82702C6.45893 9.99963 6.67885 10.0961 6.90442 10.1161C7.19118 10.1435 7.48755 10.0466 7.70715 9.82702L11.9503 5.58486C12.3402 5.19441 12.3403 4.56118 11.9503 4.17094C11.5599 3.78059 10.9267 3.78069 10.5363 4.17094L6.99622 7.70901L3.45715 4.17094C3.06673 3.78059 2.43355 3.78069 2.04309 4.17094Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </button>
+            <div id="visibilityDropdown" class="visibility-dropdown hidden">
+              <div
+                class="visibility-option"
+                data-value="1"
+                data-i18n="visibility_anyone"
+              >
+                Anyone
+              </div>
+              <div
+                class="visibility-option"
+                data-value="2"
+                data-i18n="visibility_unlisted"
+              >
+                Unlisted
+              </div>
+              <div
+                class="visibility-option selected"
+                data-value="3"
+                data-i18n="visibility_private"
+              >
+                Private
+              </div>
+            </div>
+          </div>
+          <label id="crewShareToggle" class="crew-share-toggle hidden">
+            <input type="checkbox" id="crewShareCheckbox" />
+            <span class="crew-share-label" data-i18n="share_with_crew"
+              >Share with crew</span
+            >
+          </label>
           <div id="playlistSelector" class="playlist-selector">
             <button
               id="playlistSelectorButton"

--- a/popup.html
+++ b/popup.html
@@ -493,12 +493,31 @@
               </div>
             </div>
           </div>
-          <label id="crewShareToggle" class="crew-share-toggle hidden">
-            <input type="checkbox" id="crewShareCheckbox" />
+          <div
+            id="crewShareToggle"
+            class="crew-share-toggle hidden"
+            role="checkbox"
+            aria-checked="false"
+            tabindex="0"
+            data-state="unchecked"
+          >
+            <div class="crew-share-checkbox">
+              <svg
+                class="crew-share-check"
+                viewBox="0 0 14 14"
+                fill="currentColor"
+              >
+                <path
+                  fill-rule="evenodd"
+                  clip-rule="evenodd"
+                  d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"
+                />
+              </svg>
+            </div>
             <span class="crew-share-label" data-i18n="share_with_crew"
               >Share with crew</span
             >
-          </label>
+          </div>
           <div id="playlistSelector" class="playlist-selector">
             <button
               id="playlistSelectorButton"

--- a/popup.html
+++ b/popup.html
@@ -444,79 +444,79 @@
               </svg>
             </button>
           </div>
-          <div id="visibilitySelector" class="visibility-selector">
-            <button
-              id="visibilitySelectorButton"
-              class="visibility-selector-button"
-              type="button"
-            >
-              <span
-                id="visibilitySelectorLabel"
-                class="visibility-selector-label"
-                data-i18n="visibility_private"
-                >Private</span
+          <div class="visibility-row">
+            <div id="visibilitySelector" class="visibility-selector">
+              <button
+                id="visibilitySelectorButton"
+                class="visibility-selector-button"
+                type="button"
               >
-              <svg
-                class="icon-chevron-down"
-                viewBox="0 0 14 14"
-                fill="currentColor"
-                width="12"
-                height="12"
-              >
-                <path
-                  d="M2.04309 4.17094C1.6528 4.56138 1.6529 5.19456 2.04309 5.58486L6.28625 9.82702C6.45893 9.99963 6.67885 10.0961 6.90442 10.1161C7.19118 10.1435 7.48755 10.0466 7.70715 9.82702L11.9503 5.58486C12.3402 5.19441 12.3403 4.56118 11.9503 4.17094C11.5599 3.78059 10.9267 3.78069 10.5363 4.17094L6.99622 7.70901L3.45715 4.17094C3.06673 3.78059 2.43355 3.78069 2.04309 4.17094Z"
+                <span
+                  id="visibilitySelectorLabel"
+                  class="visibility-selector-label"
+                  data-i18n="visibility_private"
+                  >Private</span
+                >
+                <svg
+                  class="icon-chevron-down"
+                  viewBox="0 0 14 14"
                   fill="currentColor"
-                />
-              </svg>
-            </button>
-            <div id="visibilityDropdown" class="visibility-dropdown hidden">
-              <div
-                class="visibility-option"
-                data-value="1"
-                data-i18n="visibility_anyone"
-              >
-                Anyone
-              </div>
-              <div
-                class="visibility-option"
-                data-value="2"
-                data-i18n="visibility_unlisted"
-              >
-                Unlisted
-              </div>
-              <div
-                class="visibility-option selected"
-                data-value="3"
-                data-i18n="visibility_private"
-              >
-                Private
+                  width="12"
+                  height="12"
+                >
+                  <path
+                    d="M2.04309 4.17094C1.6528 4.56138 1.6529 5.19456 2.04309 5.58486L6.28625 9.82702C6.45893 9.99963 6.67885 10.0961 6.90442 10.1161C7.19118 10.1435 7.48755 10.0466 7.70715 9.82702L11.9503 5.58486C12.3402 5.19441 12.3403 4.56118 11.9503 4.17094C11.5599 3.78059 10.9267 3.78069 10.5363 4.17094L6.99622 7.70901L3.45715 4.17094C3.06673 3.78059 2.43355 3.78069 2.04309 4.17094Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </button>
+              <div id="visibilityDropdown" class="visibility-dropdown hidden">
+                <div
+                  class="visibility-option"
+                  data-value="1"
+                  data-i18n="visibility_anyone"
+                >
+                  Anyone
+                </div>
+                <div
+                  class="visibility-option"
+                  data-value="2"
+                  data-i18n="visibility_unlisted"
+                >
+                  Unlisted
+                </div>
+                <div
+                  class="visibility-option selected"
+                  data-value="3"
+                  data-i18n="visibility_private"
+                >
+                  Private
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            id="crewShareToggle"
-            class="crew-share-toggle hidden"
-            role="checkbox"
-            aria-checked="false"
-            tabindex="0"
-            data-state="unchecked"
-          >
-            <div class="crew-share-checkbox">
-              <svg
-                class="crew-share-check"
-                viewBox="0 0 14 14"
-                fill="currentColor"
-              >
-                <path
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"
-                  d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"
-                />
-              </svg>
-            </div>
-            <span class="crew-share-label" data-i18n="share_with_crew"
-              >Share with crew</span
+            <div
+              id="crewShareToggle"
+              class="crew-share-toggle hidden"
+              role="checkbox"
+              aria-checked="false"
+              tabindex="0"
+              data-state="unchecked"
             >
+              <div class="crew-share-checkbox">
+                <svg
+                  class="crew-share-check"
+                  viewBox="0 0 14 14"
+                  fill="currentColor"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"
+                  />
+                </svg>
+              </div>
+              <span class="crew-share-label" data-i18n="crew_label">Crew</span>
+            </div>
           </div>
           <div id="playlistSelector" class="playlist-selector">
             <button

--- a/popup.js
+++ b/popup.js
@@ -136,7 +136,21 @@ function initVisibilitySelector(gbAuth) {
 
   // Show crew share toggle if user is in a crew
   if (gbAuth?.hasCrew) {
-    document.getElementById('crewShareToggle')?.classList.remove('hidden')
+    const toggle = document.getElementById('crewShareToggle')
+    if (toggle) {
+      toggle.classList.remove('hidden')
+      toggle.addEventListener('click', () => {
+        const isChecked = toggle.dataset.state === 'checked'
+        toggle.dataset.state = isChecked ? 'unchecked' : 'checked'
+        toggle.setAttribute('aria-checked', String(!isChecked))
+      })
+      toggle.addEventListener('keydown', (e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault()
+          toggle.click()
+        }
+      })
+    }
   }
 }
 
@@ -161,7 +175,7 @@ function getSelectedVisibility() {
 }
 
 function shouldShareWithCrew() {
-  return document.getElementById('crewShareCheckbox')?.checked === true
+  return document.getElementById('crewShareToggle')?.dataset.state === 'checked'
 }
 
 // ==========================================

--- a/popup.js
+++ b/popup.js
@@ -87,6 +87,83 @@ let conflictResolutions = null // Map of game_id → 'import' | 'skip' (after us
 // Age ticker state
 let ageTickerInterval = null
 
+// Visibility selector state
+let selectedVisibility = 3 // Default to Private
+
+const VISIBILITY_LABELS = {
+  1: 'visibility_anyone',
+  2: 'visibility_unlisted',
+  3: 'visibility_private'
+}
+
+function initVisibilitySelector(gbAuth) {
+  selectedVisibility = gbAuth?.defaultImportVisibility || 3
+
+  const button = document.getElementById('visibilitySelectorButton')
+  const dropdown = document.getElementById('visibilityDropdown')
+  const label = document.getElementById('visibilitySelectorLabel')
+
+  if (!button || !dropdown || !label) return
+
+  // Set initial label
+  updateVisibilityLabel()
+
+  // Mark initial selected option
+  updateVisibilitySelection()
+
+  // Toggle dropdown on button click
+  button.addEventListener('click', (e) => {
+    e.stopPropagation()
+    dropdown.classList.toggle('hidden')
+  })
+
+  // Handle option clicks
+  dropdown.querySelectorAll('.visibility-option').forEach((option) => {
+    option.addEventListener('click', () => {
+      selectedVisibility = parseInt(option.dataset.value, 10)
+      updateVisibilityLabel()
+      updateVisibilitySelection()
+      dropdown.classList.add('hidden')
+    })
+  })
+
+  // Close dropdown when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!button.contains(e.target) && !dropdown.contains(e.target)) {
+      dropdown.classList.add('hidden')
+    }
+  })
+
+  // Show crew share toggle if user is in a crew
+  if (gbAuth?.hasCrew) {
+    document.getElementById('crewShareToggle')?.classList.remove('hidden')
+  }
+}
+
+function updateVisibilityLabel() {
+  const label = document.getElementById('visibilitySelectorLabel')
+  if (label) label.textContent = t(VISIBILITY_LABELS[selectedVisibility])
+}
+
+function updateVisibilitySelection() {
+  const dropdown = document.getElementById('visibilityDropdown')
+  if (!dropdown) return
+  dropdown.querySelectorAll('.visibility-option').forEach((opt) => {
+    opt.classList.toggle(
+      'selected',
+      parseInt(opt.dataset.value, 10) === selectedVisibility
+    )
+  })
+}
+
+function getSelectedVisibility() {
+  return selectedVisibility
+}
+
+function shouldShareWithCrew() {
+  return document.getElementById('crewShareCheckbox')?.checked === true
+}
+
 // ==========================================
 // INITIALIZATION
 // ==========================================
@@ -133,6 +210,7 @@ async function initializeApp() {
     updateLanguageToggleUI()
     updateTabVisibility(gbAuth.role)
     initializeEventListeners()
+    initVisibilitySelector(gbAuth)
 
     // Hide pop-out button if already in standalone window
     chrome.windows.getCurrent((win) => {
@@ -1850,12 +1928,16 @@ async function handleDetailImport() {
       const playlists = getSelectedPlaylists()
       const partyName =
         document.getElementById('partyNameInput')?.value?.trim() || null
+      const visibility = getSelectedVisibility()
+      const shareWithCrew = shouldShareWithCrew()
       uploadResponse = await chrome.runtime.sendMessage({
         action: 'uploadPartyData',
         data: dataToUpload,
         raidId: raid?.id || null,
         playlistIds: playlists.map((p) => p.id),
-        name: partyName
+        name: partyName,
+        visibility,
+        shareWithCrew
       })
     } else if (currentDetailDataType.startsWith('detail_')) {
       uploadResponse = await chrome.runtime.sendMessage({
@@ -1959,6 +2041,8 @@ async function handleLogin() {
       language,
       role: userInfo.role || 0,
       simplePortraits: userInfo.simple_portraits || false,
+      defaultImportVisibility: userInfo.default_import_visibility || 1,
+      hasCrew: !!(userInfo.has_crew || userInfo.crew_name || userInfo.gamertag),
       user: {
         ...gbAuth.user,
         username: userInfo.username || gbAuth.user.username
@@ -2096,6 +2180,9 @@ async function refreshUserInfo(gbAuth) {
       language: userInfo.language || gbAuth.language,
       role: userInfo.role ?? gbAuth.role,
       simplePortraits: userInfo.simple_portraits || false,
+      defaultImportVisibility:
+        userInfo.default_import_visibility ?? gbAuth.defaultImportVisibility,
+      hasCrew: !!(userInfo.has_crew || userInfo.crew_name || userInfo.gamertag),
       user: {
         ...gbAuth.user,
         username: userInfo.username || gbAuth.user.username
@@ -2108,6 +2195,8 @@ async function refreshUserInfo(gbAuth) {
       updated.language !== gbAuth.language ||
       updated.role !== gbAuth.role ||
       updated.simplePortraits !== gbAuth.simplePortraits ||
+      updated.defaultImportVisibility !== gbAuth.defaultImportVisibility ||
+      updated.hasCrew !== gbAuth.hasCrew ||
       updated.user.username !== gbAuth.user?.username
 
     if (changed) {


### PR DESCRIPTION
Adds a custom visibility dropdown and crew share checkbox to #partyMeta when importing parties.

- Visibility dropdown (Anyone/Unlisted/Private) styled to match existing meta fields
- Crew share toggle, shown only if user is in a crew
- Stores user's default_import_visibility and crew status at login
- Passes visibility and shareWithCrew through to the API on import
- i18n strings for EN/JA

Requires jedmund/hensei-api#import-visibility for the API to accept the visibility override.