### PR TITLE
playlist create sheet view + input consistency

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -277,6 +277,11 @@ const strings = {
   // Playlist picker
   playlist_label: { en: 'Playlists', ja: 'プレイリスト' },
   playlist_select: { en: 'Select Playlists', ja: 'プレイリストを選択' },
+  playlist_new: { en: 'New Playlist', ja: '新規プレイリスト' },
+  playlist_create_with: {
+    en: 'Create "{name}"',
+    ja: '「{name}」を作成'
+  },
   playlist_search: { en: 'Search playlists...', ja: 'プレイリストを検索...' },
   playlist_title_field: { en: 'Playlist title', ja: 'プレイリストタイトル' },
   playlist_desc_field: { en: 'Description (optional)', ja: '説明（任意）' },

--- a/playlist-picker.js
+++ b/playlist-picker.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Playlist picker view for selecting playlists before party import.
- * Mirrors the raid-picker pattern with multi-select, search, and inline creation.
+ * Mirrors the raid-picker pattern with multi-select, search, and sheet-based creation.
  */
 
 import { t, tPlural } from './i18n.js'
@@ -13,7 +13,13 @@ let playlists = []
 let selectedPlaylists = []
 let searchQuery = ''
 let onSelectCallback = null
-let showCreateForm = false
+let playlistVisibility = 3
+
+const PLAYLIST_VISIBILITY_LABELS = {
+  1: 'playlist_public',
+  2: 'playlist_unlisted',
+  3: 'playlist_private'
+}
 
 // ==========================================
 // PUBLIC API
@@ -28,7 +34,6 @@ let showCreateForm = false
 export async function showPlaylistPicker({ currentPlaylists = [], onSelect }) {
   selectedPlaylists = [...currentPlaylists]
   onSelectCallback = onSelect
-  showCreateForm = false
 
   // Fetch playlists
   const response = await chrome.runtime.sendMessage({
@@ -52,9 +57,10 @@ export async function showPlaylistPicker({ currentPlaylists = [], onSelect }) {
  * Hide the playlist picker view
  */
 export function hidePlaylistPicker() {
+  if (onSelectCallback) onSelectCallback(selectedPlaylists)
+  hidePlaylistCreateView()
   document.getElementById('playlistPickerView').classList.remove('active')
   searchQuery = ''
-  showCreateForm = false
 }
 
 /**
@@ -93,9 +99,6 @@ function renderPicker() {
   if (searchInput) searchInput.value = ''
   searchQuery = ''
 
-  // Update create form visibility
-  updateCreateForm()
-
   // Render playlist list
   renderPlaylistList()
 }
@@ -105,14 +108,23 @@ function renderPlaylistList() {
   if (!container) return
 
   const filtered = getFilteredPlaylists()
-
-  if (playlists.length === 0) {
-    container.innerHTML = `<div class="playlist-empty">${t('playlist_no_playlists')}</div>`
-    return
-  }
+  const query = searchQuery.trim()
 
   if (filtered.length === 0) {
-    container.innerHTML = `<div class="playlist-empty">${t('playlist_no_results')}</div>`
+    const escaped = query
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+    container.innerHTML = query
+      ? `
+        <button type="button" class="playlist-item playlist-create-prompt" data-prefill="${escaped}">
+          <div class="playlist-item-info">
+            <span class="playlist-item-title">${t('playlist_create_with', { name: query })}</span>
+          </div>
+        </button>
+      `
+      : `<div class="playlist-empty">${playlists.length === 0 ? t('playlist_no_playlists') : t('playlist_no_results')}</div>`
     return
   }
 
@@ -134,7 +146,9 @@ function getFilteredPlaylists() {
 }
 
 function renderPlaylistItem(playlist) {
-  const isSelected = selectedPlaylists.some((p) => p.id === playlist.id)
+  const isSelected = selectedPlaylists.some(
+    (p) => String(p.id) === String(playlist.id)
+  )
   const title = playlist.title || t('playlist_untitled')
   const partyCount = playlist.party_count || playlist.parties_count || 0
   const countText = tPlural('count_party', 'count_parties', partyCount)
@@ -150,24 +164,31 @@ function renderPlaylistItem(playlist) {
   `
 }
 
-function updateCreateForm() {
-  const form = document.getElementById('playlistCreateForm')
-  if (!form) return
-
-  if (showCreateForm) {
-    form.classList.remove('hidden')
-  } else {
-    form.classList.add('hidden')
-    // Clear form fields
-    const titleInput = form.querySelector('#playlistCreateTitle')
-    const descInput = form.querySelector('#playlistCreateDescription')
-    const visInput = form.querySelector('#playlistCreateVisibility')
-    const errorEl = form.querySelector('.playlist-create-error')
-    if (titleInput) titleInput.value = ''
-    if (descInput) descInput.value = ''
-    if (visInput) visInput.value = '3'
-    if (errorEl) errorEl.textContent = ''
+function showPlaylistCreateView(prefillTitle) {
+  if (prefillTitle) {
+    const titleInput = document.getElementById('playlistCreateTitle')
+    if (titleInput) titleInput.value = prefillTitle
   }
+  document.getElementById('playlistCreateView')?.classList.add('active')
+  updateCreateSubmitState()
+}
+
+function hidePlaylistCreateView() {
+  const view = document.getElementById('playlistCreateView')
+  if (!view) return
+  view.classList.remove('active')
+
+  // Clear form fields
+  const titleInput = view.querySelector('#playlistCreateTitle')
+  const descInput = view.querySelector('#playlistCreateDescription')
+  const errorEl = view.querySelector('.playlist-create-error')
+  if (titleInput) titleInput.value = ''
+  if (descInput) descInput.value = ''
+  if (errorEl) errorEl.textContent = ''
+  updateCreateSubmitState()
+  playlistVisibility = 3
+  updatePlaylistVisibilityLabel()
+  updatePlaylistVisibilitySelection()
 }
 
 // ==========================================
@@ -193,13 +214,49 @@ function bindEvents() {
       renderPlaylistList()
     })
 
-  // Create button (toggle form)
+  // Create button (show create view)
   document
     .getElementById('playlistCreateBtn')
-    ?.addEventListener('click', () => {
-      showCreateForm = !showCreateForm
-      updateCreateForm()
+    ?.addEventListener('click', () => showPlaylistCreateView())
+
+  // Validate create form on title input
+  document
+    .getElementById('playlistCreateTitle')
+    ?.addEventListener('input', updateCreateSubmitState)
+
+  // Create view back button
+  document
+    .getElementById('playlistCreateBack')
+    ?.addEventListener('click', hidePlaylistCreateView)
+
+  // Playlist visibility selector
+  const plVisBtn = document.getElementById('playlistVisibilityButton')
+  const plVisDrop = document.getElementById('playlistVisibilityDropdown')
+
+  plVisBtn?.addEventListener('click', (e) => {
+    e.stopPropagation()
+    plVisDrop?.classList.toggle('hidden')
+  })
+
+  plVisDrop?.querySelectorAll('.visibility-option').forEach((option) => {
+    option.addEventListener('click', () => {
+      playlistVisibility = parseInt(option.dataset.value, 10)
+      updatePlaylistVisibilityLabel()
+      updatePlaylistVisibilitySelection()
+      plVisDrop.classList.add('hidden')
     })
+  })
+
+  document.addEventListener('click', (e) => {
+    if (
+      plVisBtn &&
+      plVisDrop &&
+      !plVisBtn.contains(e.target) &&
+      !plVisDrop.contains(e.target)
+    ) {
+      plVisDrop.classList.add('hidden')
+    }
+  })
 
   // Submit create form
   document
@@ -210,16 +267,22 @@ function bindEvents() {
   document
     .getElementById('playlistPickerContent')
     ?.addEventListener('click', (e) => {
+      const createPrompt = e.target.closest('.playlist-create-prompt')
+      if (createPrompt) {
+        showPlaylistCreateView(createPrompt.dataset.prefill)
+        return
+      }
+
       const playlistItem = e.target.closest('.playlist-item')
       if (!playlistItem) return
 
       const playlistId = playlistItem.dataset.playlistId
-      const playlist = playlists.find((p) => p.id === playlistId)
+      const playlist = playlists.find((p) => String(p.id) === playlistId)
       if (!playlist) return
 
       // Toggle: clicking toggles selection
       const existingIndex = selectedPlaylists.findIndex(
-        (p) => p.id === playlist.id
+        (p) => String(p.id) === String(playlist.id)
       )
       if (existingIndex >= 0) {
         selectedPlaylists.splice(existingIndex, 1)
@@ -233,16 +296,12 @@ function bindEvents() {
   // Done button
   document
     .getElementById('playlistPickerDone')
-    ?.addEventListener('click', () => {
-      if (onSelectCallback) onSelectCallback(selectedPlaylists)
-      hidePlaylistPicker()
-    })
+    ?.addEventListener('click', hidePlaylistPicker)
 }
 
 async function handleCreatePlaylist() {
   const titleInput = document.getElementById('playlistCreateTitle')
   const descInput = document.getElementById('playlistCreateDescription')
-  const visInput = document.getElementById('playlistCreateVisibility')
   const errorEl = document.querySelector('.playlist-create-error')
   const submitBtn = document.getElementById('playlistCreateSubmit')
 
@@ -263,7 +322,7 @@ async function handleCreatePlaylist() {
     data: {
       title,
       description: descInput?.value?.trim() || '',
-      visibility: parseInt(visInput?.value || '3')
+      visibility: playlistVisibility
     }
   })
 
@@ -277,13 +336,50 @@ async function handleCreatePlaylist() {
     return
   }
 
-  // Add new playlist to local list and auto-select it
-  const newPlaylist = response.data || response
-  playlists.unshift(newPlaylist)
+  // Auto-select the new playlist
+  const responseData = response.data || response
+  const newPlaylist = responseData.playlist || responseData
+  if (!newPlaylist.title) newPlaylist.title = title
   selectedPlaylists.push(newPlaylist)
 
-  // Hide form and re-render
-  showCreateForm = false
-  updateCreateForm()
+  // Re-fetch playlists, clear search, and go back
+  const refreshResponse = await chrome.runtime.sendMessage({
+    action: 'fetchUserPlaylists'
+  })
+  playlists = refreshResponse.data?.results || refreshResponse.data || []
+
+  // Reconcile selected playlists with fresh data
+  selectedPlaylists = selectedPlaylists.map(
+    (s) => playlists.find((p) => String(p.id) === String(s.id)) || s
+  )
+
+  searchQuery = ''
+  const searchInput = document.getElementById('playlistSearchInput')
+  if (searchInput) searchInput.value = ''
+
+  hidePlaylistCreateView()
   renderPlaylistList()
+}
+
+function updatePlaylistVisibilityLabel() {
+  const label = document.getElementById('playlistVisibilityLabel')
+  if (label)
+    label.textContent = t(PLAYLIST_VISIBILITY_LABELS[playlistVisibility])
+}
+
+function updateCreateSubmitState() {
+  const title = document.getElementById('playlistCreateTitle')?.value?.trim()
+  const btn = document.getElementById('playlistCreateSubmit')
+  if (btn) btn.disabled = !title
+}
+
+function updatePlaylistVisibilitySelection() {
+  const dropdown = document.getElementById('playlistVisibilityDropdown')
+  if (!dropdown) return
+  dropdown.querySelectorAll('.visibility-option').forEach((opt) => {
+    opt.classList.toggle(
+      'selected',
+      parseInt(opt.dataset.value, 10) === playlistVisibility
+    )
+  })
 }

--- a/popup.css
+++ b/popup.css
@@ -1144,21 +1144,27 @@ button:disabled,
   opacity: 0.7;
 }
 
-/* Elemental Import button in detail view */
+/* Elemental buttons in detail view */
 #detailImport,
-#detailSync {
+#detailSync,
+#playlistCreateBtn,
+#playlistCreateSubmit {
   background-color: var(--element-button-bg);
   border: none;
   color: white;
 }
 
 #detailImport:hover:not(:disabled),
-#detailSync:hover:not(:disabled) {
+#detailSync:hover:not(:disabled),
+#playlistCreateBtn:hover:not(:disabled),
+#playlistCreateSubmit:hover:not(:disabled) {
   background-color: var(--element-button-bg-hover);
 }
 
 body.light #detailImport,
-body.light #detailSync {
+body.light #detailSync,
+body.light #playlistCreateBtn,
+body.light #playlistCreateSubmit {
   color: var(--element-button-text, white);
 }
 
@@ -2703,23 +2709,27 @@ body.light #detailSync {
   color: var(--color-text);
 }
 
-.playlist-create-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius-md);
-  color: var(--color-text-tertiary);
-  cursor: pointer;
+.playlist-picker-header .button.small {
   flex-shrink: 0;
-  transition: color var(--transition-fast);
 }
 
-.playlist-create-btn:hover {
-  color: var(--color-text);
+/* Create View (slides over playlist picker) */
+.playlist-create-view {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: white;
+  transform: translateX(100%);
+  transition: transform 0.3s ease-out;
+  display: flex;
+  flex-direction: column;
+  z-index: 300;
+}
+
+.playlist-create-view.active {
+  transform: translateX(0);
 }
 
 /* Create Form */
@@ -2728,21 +2738,10 @@ body.light #detailSync {
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--color-border-light);
-  flex-shrink: 0;
 }
 
 .playlist-create-form textarea.contained {
-  resize: none;
-  padding: 12px;
-  font-size: 14px;
-  font-family: inherit;
-}
-
-.playlist-create-form select.contained {
-  padding: 12px;
-  font-size: 14px;
-  font-family: inherit;
+  resize: vertical;
 }
 
 .playlist-create-error {
@@ -2804,7 +2803,7 @@ body.light #detailSync {
 }
 
 .playlist-item.selected {
-  background: var(--element-bg);
+  background: transparent;
 }
 
 .playlist-item-info {
@@ -2830,14 +2829,16 @@ body.light #detailSync {
 }
 
 .playlist-item-check {
-  color: var(--element-text);
+  color: var(--element-button-bg);
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
 }
 
 /* Footer */
 .playlist-picker-footer {
   padding: 12px 16px;
-  border-top: 1px solid var(--color-border-light);
+  border-top: none;
   flex-shrink: 0;
 }
 

--- a/popup.css
+++ b/popup.css
@@ -2162,49 +2162,19 @@ body.light #detailSync {
   gap: 8px;
   width: 100%;
   padding: 8px 16px;
-  background: var(--color-bg);
+  background: var(--input-bound-bg);
   border: none;
-  border-radius: var(--radius-md);
-  min-height: 50px;
+  border-radius: var(--input-corner);
   font-family: inherit;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: var(--input-font-size);
+  font-weight: 400;
   color: var(--color-text);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition: background-color var(--transition-fast);
 }
 
 .raid-selector-button:hover {
-  background: var(--button-bg-hover);
-}
-
-.raid-selector-button.raid-fire {
-  background: #ffcdcd;
-  color: #6e0000;
-}
-.raid-selector-button.raid-wind {
-  background: #cdffed;
-  color: #006a45;
-}
-.raid-selector-button.raid-water {
-  background: #cdedff;
-  color: #004b77;
-}
-.raid-selector-button.raid-earth {
-  background: #ffe2cd;
-  color: #863504;
-}
-.raid-selector-button.raid-light {
-  background: #fffacd;
-  color: #715100;
-}
-.raid-selector-button.raid-dark {
-  background: #f2cdff;
-  color: #560075;
-}
-.raid-selector-button.raid-null {
-  background: var(--color-bg);
-  color: var(--color-text);
+  background-color: var(--input-bound-bg-hover);
 }
 
 .raid-selector-image {
@@ -2500,21 +2470,20 @@ body.light #detailSync {
   align-items: center;
   gap: 8px;
   width: 100%;
-  min-height: 50px;
-  padding: 8px 16px;
-  background: var(--color-bg);
+  padding: var(--input-padding);
+  background: var(--input-bound-bg);
   border: none;
-  border-radius: var(--radius-md);
+  border-radius: var(--input-corner);
   font-family: inherit;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: var(--input-font-size);
+  font-weight: 400;
   color: var(--color-text);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition: background-color var(--transition-fast);
 }
 
 .playlist-selector-button:hover {
-  background: var(--button-bg-hover);
+  background-color: var(--input-bound-bg-hover);
 }
 
 .playlist-selector-label {
@@ -2542,21 +2511,30 @@ body.light #detailSync {
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 8px 16px;
-  background: var(--color-bg);
-  border: none;
-  border-radius: var(--radius-md);
-  min-height: 50px;
+  padding: var(--input-padding);
+  background: var(--input-bg);
+  border: var(--input-border);
+  border-radius: var(--input-corner);
   font-family: inherit;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: var(--input-font-size);
+  font-weight: 400;
   color: var(--color-text);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition: background-color var(--transition-fast);
 }
 
 .visibility-selector-button:hover {
-  background: var(--button-bg-hover);
+  background-color: var(--input-bg-hover);
+}
+
+.visibility-selector-button.contained {
+  background-color: var(--input-bound-bg);
+  border: none;
+  border-radius: 8px;
+}
+
+.visibility-selector-button.contained:hover {
+  background-color: var(--input-bound-bg-hover);
 }
 
 .visibility-selector-label {
@@ -2623,14 +2601,13 @@ body.light #detailSync {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 16px;
-  background: var(--color-bg);
+  padding: var(--input-padding);
+  background: var(--input-bound-bg);
   border: none;
-  border-radius: var(--radius-md);
-  min-height: 50px;
+  border-radius: var(--input-corner);
   font-family: inherit;
-  font-size: 14px;
-  font-weight: 500;
+  font-size: var(--input-font-size);
+  font-weight: 400;
   color: var(--color-text);
   cursor: pointer;
   transition: background var(--transition-fast);
@@ -2638,12 +2615,12 @@ body.light #detailSync {
 }
 
 .crew-share-toggle:hover {
-  background: var(--button-bg-hover);
+  background: var(--input-bound-bg-hover);
 }
 
 .crew-share-checkbox {
-  width: 24px;
-  height: 24px;
+  width: 21px;
+  height: 21px;
   border-radius: 8px;
   background: white;
   display: inline-flex;

--- a/popup.css
+++ b/popup.css
@@ -114,11 +114,14 @@
   --button-contained-bg: #f5f5f5;
   --button-contained-bg-hover: #e9e9e9;
 
-  /* Colors - Inputs */
+  /* Inputs */
   --input-bg: white;
   --input-bg-hover: #fafafa;
   --input-bound-bg: #f5f5f5;
   --input-bound-bg-hover: #efefef;
+  --input-padding: 14px 16px;
+  --input-font-size: 15px;
+  --input-border: 2px solid transparent;
 
   /* Colors - Accent */
   --color-primary: #275dc5;
@@ -542,17 +545,18 @@ input[type='text'],
 input[type='password'],
 input[type='email'],
 input[type='number'],
-select {
+select,
+textarea {
   -webkit-font-smoothing: antialiased;
   background-color: var(--input-bg);
   border-radius: var(--input-corner);
-  border: 2px solid transparent;
+  border: var(--input-border);
   box-sizing: border-box;
   color: var(--color-text);
   display: block;
   font-family: inherit;
-  font-size: 15px;
-  padding: 14px 16px;
+  font-size: var(--input-font-size);
+  padding: var(--input-padding);
   width: 100%;
   transition: background-color var(--transition-fast);
 }
@@ -561,28 +565,35 @@ input[type='text']:hover:not(:disabled),
 input[type='password']:hover:not(:disabled),
 input[type='email']:hover:not(:disabled),
 input[type='number']:hover:not(:disabled),
-select:hover:not(:disabled) {
+select:hover:not(:disabled),
+textarea:hover:not(:disabled) {
   background-color: var(--input-bg-hover);
 }
 
 input:focus,
-select:focus {
+select:focus,
+textarea:focus {
   outline: none;
 }
 
 /* Contained input variant */
 input.contained,
-select.contained {
+select.contained,
+textarea.contained {
   background-color: var(--input-bound-bg);
+  border: none;
+  border-radius: 8px;
 }
 
 input.contained:hover:not(:disabled),
-select.contained:hover:not(:disabled) {
+select.contained:hover:not(:disabled),
+textarea.contained:hover:not(:disabled) {
   background-color: var(--input-bound-bg-hover);
 }
 
 /* Placeholder styles */
-input::placeholder {
+input::placeholder,
+textarea::placeholder {
   color: var(--color-text-tertiary);
   opacity: 1;
 }

--- a/popup.html
+++ b/popup.html
@@ -448,7 +448,7 @@
             <div id="visibilitySelector" class="visibility-selector">
               <button
                 id="visibilitySelectorButton"
-                class="visibility-selector-button"
+                class="visibility-selector-button contained"
                 type="button"
               >
                 <span

--- a/popup.html
+++ b/popup.html
@@ -657,45 +657,14 @@
         <span class="playlist-picker-title" data-i18n="playlist_select"
           >Select Playlists</span
         >
-        <button id="playlistCreateBtn" class="playlist-create-btn">
-          <svg viewBox="0 0 14 14" fill="currentColor" width="14" height="14">
-            <path
-              d="M7 1a1 1 0 0 1 1 1v4h4a1 1 0 1 1 0 2H8v4a1 1 0 1 1-2 0V8H2a1 1 0 0 1 0-2h4V2a1 1 0 0 1 1-1z"
-            />
-          </svg>
+        <button
+          id="playlistCreateBtn"
+          class="button small"
+          data-i18n="action_new"
+        >
+          New
         </button>
       </header>
-      <div id="playlistCreateForm" class="playlist-create-form hidden">
-        <input
-          type="text"
-          id="playlistCreateTitle"
-          class="contained"
-          data-i18n-placeholder="playlist_title_field"
-          placeholder="Playlist title"
-        />
-        <textarea
-          id="playlistCreateDescription"
-          class="contained"
-          data-i18n-placeholder="playlist_desc_field"
-          placeholder="Description (optional)"
-          rows="2"
-        ></textarea>
-        <select id="playlistCreateVisibility" class="contained">
-          <option value="3" selected data-i18n="playlist_private">
-            Private
-          </option>
-          <option value="2" data-i18n="playlist_unlisted">Unlisted</option>
-          <option value="1" data-i18n="playlist_public">Public</option>
-        </select>
-        <button
-          id="playlistCreateSubmit"
-          class="button btn-primary small"
-          data-i18n="action_create"
-        >
-          Create
-        </button>
-        <div class="playlist-create-error"></div>
-      </div>
       <div class="playlist-picker-search">
         <input
           type="text"
@@ -716,6 +685,98 @@
         >
           Done
         </button>
+      </div>
+    </div>
+
+    <!-- Playlist Create View (slides over playlist picker) -->
+    <div id="playlistCreateView" class="playlist-create-view">
+      <header class="playlist-picker-header">
+        <button id="playlistCreateBack" class="detail-back">
+          <svg class="icon-chevron" viewBox="0 0 14 14" fill="currentColor">
+            <path
+              d="M9.82906 2.04309C9.43862 1.6528 8.8055 1.6529 8.415 2.04309L4.17281 6.28625C4.0002 6.45893 3.9037 6.67885 3.88375 6.90442C3.85638 7.19118 3.95321 7.48755 4.17281 7.70715L8.415 11.9503C8.80545 12.3402 9.43867 12.3403 9.82906 11.9503C10.2192 11.5599 10.219 10.9267 9.82906 10.5363L6.29098 6.99622L9.82906 3.45715C10.2192 3.06673 10.2191 2.43355 9.82906 2.04309Z"
+              fill="currentColor"
+            />
+          </svg>
+          <span data-i18n="action_back">Back</span>
+        </button>
+        <span class="playlist-picker-title" data-i18n="playlist_new"
+          >New Playlist</span
+        >
+        <button
+          id="playlistCreateSubmit"
+          class="button small"
+          data-i18n="action_create"
+          disabled
+        >
+          Create
+        </button>
+      </header>
+      <div class="playlist-create-form">
+        <input
+          type="text"
+          id="playlistCreateTitle"
+          class="contained"
+          data-i18n-placeholder="playlist_title_field"
+          placeholder="Playlist title"
+        />
+        <textarea
+          id="playlistCreateDescription"
+          class="contained"
+          data-i18n-placeholder="playlist_desc_field"
+          placeholder="Description (optional)"
+          rows="2"
+        ></textarea>
+        <div id="playlistVisibilitySelector" class="visibility-selector">
+          <button
+            id="playlistVisibilityButton"
+            class="visibility-selector-button contained"
+            type="button"
+          >
+            <span
+              id="playlistVisibilityLabel"
+              class="visibility-selector-label"
+              data-i18n="playlist_private"
+              >Private</span
+            >
+            <svg
+              class="icon-chevron-down"
+              viewBox="0 0 14 14"
+              fill="currentColor"
+              width="12"
+              height="12"
+            >
+              <path
+                d="M2.04309 4.17094C1.6528 4.56138 1.6529 5.19456 2.04309 5.58486L6.28625 9.82702C6.45893 9.99963 6.67885 10.0961 6.90442 10.1161C7.19118 10.1435 7.48755 10.0466 7.70715 9.82702L11.9503 5.58486C12.3402 5.19441 12.3403 4.56118 11.9503 4.17094C11.5599 3.78059 10.9267 3.78069 10.5363 4.17094L6.99622 7.70901L3.45715 4.17094C3.06673 3.78059 2.43355 3.78069 2.04309 4.17094Z"
+                fill="currentColor"
+              />
+            </svg>
+          </button>
+          <div id="playlistVisibilityDropdown" class="visibility-dropdown hidden">
+            <div
+              class="visibility-option"
+              data-value="1"
+              data-i18n="playlist_public"
+            >
+              Public
+            </div>
+            <div
+              class="visibility-option"
+              data-value="2"
+              data-i18n="playlist_unlisted"
+            >
+              Unlisted
+            </div>
+            <div
+              class="visibility-option selected"
+              data-value="3"
+              data-i18n="playlist_private"
+            >
+              Private
+            </div>
+          </div>
+        </div>
+        <div class="playlist-create-error"></div>
       </div>
     </div>
 

--- a/popup.html
+++ b/popup.html
@@ -752,7 +752,10 @@
               />
             </svg>
           </button>
-          <div id="playlistVisibilityDropdown" class="visibility-dropdown hidden">
+          <div
+            id="playlistVisibilityDropdown"
+            class="visibility-dropdown hidden"
+          >
             <div
               class="visibility-option"
               data-value="1"

--- a/popup.js
+++ b/popup.js
@@ -833,26 +833,11 @@ function hideDetailView() {
  * Update the raid selector button UI to reflect the selected raid
  * @param {Object|null} raid
  */
-const RAID_ELEMENT_CLASSES = {
-  0: 'raid-null',
-  1: 'raid-wind',
-  2: 'raid-fire',
-  3: 'raid-water',
-  4: 'raid-earth',
-  5: 'raid-dark',
-  6: 'raid-light'
-}
-
 function updateRaidSelectorUI(raid) {
   const label = document.getElementById('raidSelectorLabel')
   const btn = document.getElementById('raidSelectorButton')
   const img = document.getElementById('raidSelectorImage')
   if (!label || !btn) return
-
-  // Remove any previous element class
-  Object.values(RAID_ELEMENT_CLASSES).forEach((cls) =>
-    btn.classList.remove(cls)
-  )
 
   if (raid) {
     const name =
@@ -861,8 +846,6 @@ function updateRaidSelectorUI(raid) {
         : raid.name?.en || raid.name_en || 'Unknown'
     const level = raid.level ? ` Lv. ${raid.level}` : ''
     label.textContent = `${name}${level}`
-    const elementClass = RAID_ELEMENT_CLASSES[raid.element] || 'raid-null'
-    btn.classList.add(elementClass)
 
     // Show raid thumbnail
     if (img && raid.slug) {


### PR DESCRIPTION
## Summary
- Move playlist create form from inline toggle to a pushed sheet view (z-index 300)
- Componentize input styles with CSS variables (`--input-padding`, `--input-font-size`, `--input-border`)
- Standardize all selector buttons (raid, playlist, visibility, crew) to use shared input variables
- Remove element coloring from raid selector — always grey now
- New/Create buttons use elemental color, Create disabled until title filled
- Custom visibility dropdown in create form (matches party import)
- "Create playlist" prompt when search has no results, prefills title
- Back button on picker fires selection callback (Done button kept)
- Re-fetch playlists after creation, reconcile selected state
- Crew checkbox 21px, playlist checkmark uses vibrant element color

## Test plan
- [ ] Open playlist picker from party import
- [ ] Tap New, verify sheet slides in
- [ ] Create a playlist, verify auto-selected and list refreshed
- [ ] Search for nonexistent name, verify create prompt appears
- [ ] Tap create prompt, verify title prefilled
- [ ] Back from picker applies selection correctly
- [ ] Verify raid/playlist/visibility/crew triggers all have consistent styles
- [ ] Verify textarea description matches input styles