### PR TITLE
move update notice to bottom as floating card

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -425,6 +425,7 @@ const strings = {
     ja: '新しいバージョンがあります（v'
   },
   update_link: { en: 'Update', ja: '更新' },
+  update_current: { en: "You're currently on v", ja: '現在のバージョン：v' },
 
   // Party name
   party_name_placeholder: { en: 'Party name', ja: 'パーティ名' },

--- a/popup.css
+++ b/popup.css
@@ -469,16 +469,12 @@ body.dark .tab.active {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  position: fixed;
-  bottom: var(--spacing-sm);
-  left: var(--spacing-md);
-  right: var(--spacing-md);
+  margin: var(--spacing-sm) var(--spacing-md) var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-primary-light);
   border-radius: var(--radius-lg);
   font-size: 12px;
   color: var(--color-primary);
-  z-index: 100;
 }
 
 .update-banner .update-link {

--- a/popup.css
+++ b/popup.css
@@ -473,7 +473,8 @@ body.dark .tab.active {
   bottom: var(--spacing-sm);
   left: var(--spacing-md);
   right: var(--spacing-md);
-  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-sm)
+    var(--spacing-md);
   background: var(--color-primary-light);
   border-radius: var(--radius-xl);
   font-size: 14px;

--- a/popup.css
+++ b/popup.css
@@ -473,12 +473,23 @@ body.dark .tab.active {
   bottom: var(--spacing-sm);
   left: var(--spacing-md);
   right: var(--spacing-md);
-  padding: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-sm) var(--spacing-md);
   background: var(--color-primary-light);
   border-radius: var(--radius-xl);
   font-size: 14px;
   color: var(--color-primary);
   z-index: 100;
+}
+
+.update-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.update-banner-subtitle {
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .update-banner .update-link {

--- a/popup.css
+++ b/popup.css
@@ -469,22 +469,26 @@ body.dark .tab.active {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: var(--spacing-sm) var(--spacing-md) var(--spacing-md);
-  padding: var(--spacing-sm) var(--spacing-md);
+  position: fixed;
+  bottom: var(--spacing-sm);
+  left: var(--spacing-md);
+  right: var(--spacing-md);
+  padding: var(--spacing-sm);
   background: var(--color-primary-light);
-  border-radius: var(--radius-lg);
-  font-size: 12px;
+  border-radius: var(--radius-xl);
+  font-size: 14px;
   color: var(--color-primary);
+  z-index: 100;
 }
 
 .update-banner .update-link {
   color: var(--color-primary);
-  font-weight: 500;
-  text-decoration: none;
+  background-color: transparent;
 }
 
-.update-banner .update-link:hover {
-  text-decoration: underline;
+.update-banner .update-link:hover:not(:disabled) {
+  color: var(--color-primary);
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 /* ==========================================

--- a/popup.css
+++ b/popup.css
@@ -469,12 +469,16 @@ body.dark .tab.active {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: fixed;
+  bottom: var(--spacing-sm);
+  left: var(--spacing-md);
+  right: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
-  margin: var(--spacing-sm) var(--spacing-md);
   background: var(--color-primary-light);
   border-radius: var(--radius-lg);
   font-size: 12px;
   color: var(--color-primary);
+  z-index: 100;
 }
 
 .update-banner .update-link {

--- a/popup.css
+++ b/popup.css
@@ -470,8 +470,9 @@ body.dark .tab.active {
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-sm) var(--spacing-md);
+  margin: var(--spacing-sm) var(--spacing-md);
   background: var(--color-primary-light);
-  border-bottom: 1px solid var(--color-primary-border);
+  border-radius: var(--radius-lg);
   font-size: 12px;
   color: var(--color-primary);
 }

--- a/popup.html
+++ b/popup.html
@@ -81,21 +81,6 @@
 
     <!-- Main View (shown when authenticated) -->
     <div id="mainView" class="view hidden">
-      <!-- Update Banner -->
-      <div id="updateBanner" class="update-banner hidden">
-        <span
-          ><span data-i18n="update_available"
-            >A new version is available (v</span
-          ><span id="updateVersion"></span>)</span
-        >
-        <a
-          href="https://granblue.team/extension"
-          target="_blank"
-          class="update-link"
-          data-i18n="update_link"
-          >Update</a
-        >
-      </div>
       <!-- Tab Navigation -->
       <nav class="tabs">
         <button class="tab active" data-tab="party" data-i18n="nav_party">
@@ -879,6 +864,22 @@
             Done
           </button>
         </div>
+      </div>
+
+      <!-- Update Banner -->
+      <div id="updateBanner" class="update-banner hidden">
+        <span
+          ><span data-i18n="update_available"
+            >A new version is available (v</span
+          ><span id="updateVersion"></span>)</span
+        >
+        <a
+          href="https://granblue.team/extension"
+          target="_blank"
+          class="update-link"
+          data-i18n="update_link"
+          >Update</a
+        >
       </div>
     </div>
 

--- a/popup.html
+++ b/popup.html
@@ -865,22 +865,20 @@
           </button>
         </div>
       </div>
+    </div>
 
-      <!-- Update Banner -->
-      <div id="updateBanner" class="update-banner hidden">
-        <span
-          ><span data-i18n="update_available"
-            >A new version is available (v</span
-          ><span id="updateVersion"></span>)</span
-        >
-        <a
-          href="https://granblue.team/extension"
-          target="_blank"
-          class="update-link"
-          data-i18n="update_link"
-          >Update</a
-        >
-      </div>
+    <!-- Update Banner -->
+    <div id="updateBanner" class="update-banner hidden">
+      <span
+        ><span data-i18n="update_available"
+          >A new version is available (v</span
+        ><span id="updateVersion"></span>)</span
+      >
+      <button
+        class="button btn-ghost small update-link"
+        data-i18n="update_link"
+        onclick="window.open('https://granblue.team/extension', '_blank')"
+        >Update</button>
     </div>
 
     <div id="tooltip" class="tooltip" aria-hidden="true"></div>

--- a/popup.html
+++ b/popup.html
@@ -875,13 +875,18 @@
             >A new version is available (v</span
           ><span id="updateVersion"></span>)</span
         >
-        <span class="update-banner-subtitle"><span data-i18n="update_current">You're currently on v</span><span id="updateCurrentVersion"></span></span>
+        <span class="update-banner-subtitle"
+          ><span data-i18n="update_current">You're currently on v</span
+          ><span id="updateCurrentVersion"></span
+        ></span>
       </div>
       <button
         class="button btn-ghost small update-link"
         data-i18n="update_link"
         onclick="window.open('https://granblue.team/extension', '_blank')"
-        >Update</button>
+      >
+        Update
+      </button>
     </div>
 
     <div id="tooltip" class="tooltip" aria-hidden="true"></div>

--- a/popup.html
+++ b/popup.html
@@ -869,11 +869,14 @@
 
     <!-- Update Banner -->
     <div id="updateBanner" class="update-banner hidden">
-      <span
-        ><span data-i18n="update_available"
-          >A new version is available (v</span
-        ><span id="updateVersion"></span>)</span
-      >
+      <div class="update-banner-text">
+        <span
+          ><span data-i18n="update_available"
+            >A new version is available (v</span
+          ><span id="updateVersion"></span>)</span
+        >
+        <span class="update-banner-subtitle"><span data-i18n="update_current">You're currently on v</span><span id="updateCurrentVersion"></span></span>
+      </div>
       <button
         class="button btn-ghost small update-link"
         data-i18n="update_link"

--- a/popup.js
+++ b/popup.js
@@ -2605,6 +2605,8 @@ async function checkForUpdate() {
     const versionSpan = document.getElementById('updateVersion')
     if (!banner || !versionSpan) return
     versionSpan.textContent = response.latest
+    const currentSpan = document.getElementById('updateCurrentVersion')
+    if (currentSpan) currentSpan.textContent = response.current
     banner.classList.remove('hidden')
   }
 }


### PR DESCRIPTION
## Summary
- Move extension update banner from top of main view to bottom
- Style as floating rounded card with no border, keeps blue theme

## Test plan
- Trigger outdated version state and verify banner appears at bottom as a rounded floating card