### PR TITLE
tighten typescript, direct paraglide calls, wire up modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/chrome": "^0.1.38",
     "@wxt-dev/module-svelte": "latest",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.1.0(jiti@2.6.1))
+      '@types/chrome':
+        specifier: ^0.1.38
+        version: 0.1.38
       '@wxt-dev/module-svelte':
         specifier: latest
         version: 2.0.5(svelte@5.55.1)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.98.0))(wxt@0.20.20(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(eslint@10.1.0(jiti@2.6.1))(jiti@2.6.1)(sass@1.98.0))
@@ -578,6 +581,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chrome@0.1.38':
+    resolution: {integrity: sha512-5aK4m9wZqoWAoB98aElESLm/5pXpqJnFWMNoiCs/XdPsXR6wNdVkJFSdQ9Wr4PnTuUrxD0SuNuDHh3EG5QeBzA==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2620,6 +2626,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chrome@0.1.38':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
 
   '@types/esrecurse@4.3.1': {}
 

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -6,6 +6,8 @@
   import { getImageUrl } from '../lib/constants.js'
   import LoginView from './login/LoginView.svelte'
   import MainView from './main/MainView.svelte'
+  import WarningCard from './login/WarningCard.svelte'
+  import ConflictModal from './modals/ConflictModal.svelte'
   import Toast from './shared/Toast.svelte'
 
   onMount(async () => {
@@ -60,4 +62,11 @@
   <LoginView />
 {/if}
 
+{#if app.showingDisclaimer}
+  <div class="disclaimer-overlay">
+    <WarningCard />
+  </div>
+{/if}
+
+<ConflictModal />
 <Toast />

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { app } from '../lib/state/app.svelte.js'
+  import { app, type AuthData } from '../lib/state/app.svelte.js'
   import { setLocale, getPreferredLocale } from '../lib/i18n.js'
   import { getCacheStatus } from '../lib/services/chrome-messages.js'
   import { getImageUrl } from '../lib/constants.js'
@@ -14,16 +14,18 @@
       `url('${getImageUrl('port-breeze.jpg')}')`
     )
 
-    const { gbAuth, noticeAcknowledged } = await chrome.storage.local.get([
+    const result = await chrome.storage.local.get([
       'gbAuth',
       'noticeAcknowledged'
     ])
+    const gbAuth = result.gbAuth as AuthData | undefined
+    const noticeAcknowledged = result.noticeAcknowledged as boolean | undefined
 
-    setLocale(getPreferredLocale(gbAuth))
+    setLocale(getPreferredLocale(gbAuth ?? null))
     app.auth = gbAuth ?? null
     app.noticeAcknowledged = noticeAcknowledged ?? false
 
-    chrome.runtime.onMessage.addListener((message) => {
+    chrome.runtime.onMessage.addListener((message: { action: string; name?: string }) => {
       if (message.action === 'dataCaptured') {
         refreshCaches()
         app.showToast(

--- a/src/components/detail/DetailHeader.svelte
+++ b/src/components/detail/DetailHeader.svelte
@@ -145,11 +145,8 @@
   }
 
   function handleReview() {
-    // Review is handled by parent/modal system
-    // For now, mark as reviewed
     if (!app.pendingConflicts || app.pendingConflicts.length === 0) return
-    // TODO: open conflict resolution modal
-    app.importState = 'review'
+    app.conflictModalOpen = true
   }
 </script>
 

--- a/src/components/detail/DetailHeader.svelte
+++ b/src/components/detail/DetailHeader.svelte
@@ -65,7 +65,7 @@
     app.importState = 'importing'
 
     try {
-      let response: any
+      let response: { error?: string; url?: string; created?: number; updated?: number } | undefined
 
       if (isParty) {
         response = await uploadPartyData({
@@ -93,7 +93,7 @@
         ) {
           app.importState = 'checking'
           const conflictResponse = await checkConflicts(dataType, selectedIndices)
-          const conflicts = (conflictResponse as any)?.conflicts || (conflictResponse as any)?.data?.conflicts
+          const conflicts = conflictResponse?.conflicts
           if (conflicts && conflicts.length > 0) {
             app.pendingConflicts = conflicts
             app.importState = 'idle'

--- a/src/components/detail/DetailView.svelte
+++ b/src/components/detail/DetailView.svelte
@@ -13,6 +13,9 @@
   } from '../../lib/detail-helpers.js'
   import { getCachedData, fetchRaidGroups } from '../../lib/services/chrome-messages.js'
 
+  import type { RawGameItem } from '../../lib/detail-helpers.js'
+  import type { RaidGroup } from '../../lib/types/messages.js'
+
   import DetailHeader from './DetailHeader.svelte'
   import DetailFilter from './DetailFilter.svelte'
   import ItemGrid from './items/ItemGrid.svelte'
@@ -30,19 +33,50 @@
     isCollectionType(dataType) && dataType !== 'character_stats'
   )
 
+  interface SummonSearchResult {
+    granblue_id?: string
+    imageSuffix?: string
+    name?: { en?: string; ja?: string }
+  }
+
+  interface WeaponStatModifier {
+    nameEn?: string
+    nameJp?: string
+    suffix?: string
+    [key: string]: unknown
+  }
+
+  interface PartyDeckData {
+    deck?: {
+      pc?: {
+        weapons?: Record<string, unknown>
+        summons?: Record<string, unknown>
+        sub_summons?: Record<string, unknown>
+        damage_info?: { summon_name?: string }
+        set_action?: Array<{ name: string }>
+        [key: string]: unknown
+      }
+      npc?: Record<string, unknown>
+      name?: string
+      [key: string]: unknown
+    }
+    bullet_info?: { set_bullets?: Record<string, unknown> }
+    [key: string]: unknown
+  }
+
   // Supplementary data for parties
-  let friendSummon = $state<any>(null)
+  let friendSummon = $state<SummonSearchResult | null>(null)
   let weaponKeyMap = $state<Record<string, string> | null>(null)
   let jobSkillSlugs = $state<Record<string, string>>({})
-  let weaponStatModifiers = $state<Record<string, any> | null>(null)
+  let weaponStatModifiers = $state<Record<string, WeaponStatModifier> | null>(null)
   let simplePortraits = $state(false)
 
   // Filtered items for collection views
   let filteredItems = $derived.by(() => {
     if (!app.detailData || isParty || isDatabase || isCharStats) return []
-    const allItems = extractItems(dataType, app.detailData)
+    const allItems = extractItems(dataType, app.detailData as Record<string, unknown>)
     return allItems
-      .map((item: any, index: number) => ({ item, originalIndex: index }))
+      .map((item: RawGameItem, index: number) => ({ item, originalIndex: index }))
       .filter(({ item, originalIndex }) => {
         if (app.brokenImageIndices.has(originalIndex)) return false
         if (isWeaponOrSummonCollection(dataType)) {
@@ -84,13 +118,14 @@
   let itemCountText = $derived.by(() => {
     if (isParty || !app.detailData) return ''
     if (isCharStats) {
-      const count = Object.keys(app.detailData as any).length
+      const count = Object.keys(app.detailData as Record<string, unknown>).length
       return count === 1 ? m.count_character({ count }) : m.count_characters({ count })
     }
     if (isDatabase) {
-      return (app.detailData as any)?.name || (app.detailData as any)?.master?.name || ''
+      const detail = app.detailData as RawGameItem
+      return detail?.name || detail?.master?.name || ''
     }
-    const count = status?.totalItems || countItems(dataType, app.detailData)
+    const count = status?.totalItems || countItems(dataType, app.detailData as Record<string, unknown>)
     return count === 1 ? m.count_item({ count }) : m.count_items({ count })
   })
 
@@ -161,7 +196,7 @@
     simplePortraits = gbAuth?.simplePortraits || false
 
     if (dt.startsWith('party_')) {
-      await loadPartySupplementary(response.data)
+      await loadPartySupplementary(response.data as PartyDeckData)
     }
 
     if (dt.includes('weapon') || dt.startsWith('stash_weapon')) {
@@ -170,21 +205,22 @@
 
     // Auto-suggest raid for parties
     if (dt.startsWith('party_')) {
-      const deck = response.data?.deck || {}
-      const pc = deck.pc || {}
-      const chars = toArray(deck.npc).filter(Boolean).length
-      const wpns = toArray(pc.weapons).filter(Boolean).length
-      app.partyName = deck.name || ''
+      const partyData = response.data as PartyDeckData | undefined
+      const deck = partyData?.deck
+      const pc = deck?.pc
+      const chars = toArray(deck?.npc).filter(Boolean).length
+      const wpns = toArray(pc?.weapons).filter(Boolean).length
+      app.partyName = deck?.name || ''
       await autoSuggestRaid(wpns, chars)
     }
 
     app.detailViewActive = true
   }
 
-  async function loadPartySupplementary(data: any) {
+  async function loadPartySupplementary(data: PartyDeckData) {
     const summonName = data?.deck?.pc?.damage_info?.summon_name
     const setAction = data?.deck?.pc?.set_action || []
-    const skillNames = setAction.map((s: any) => s.name).filter(Boolean)
+    const skillNames = setAction.map((s) => s.name).filter(Boolean)
 
     const [summonResult, keyMap, skillSlugs, statMods] = await Promise.all([
       summonName ? searchSummonByName(summonName) : Promise.resolve(null),
@@ -216,7 +252,7 @@
       if (!response.ok) return null
       const json = await response.json()
       const results = json.results || []
-      return results.find((s: any) => s.name?.en === name || s.name?.ja === name) || null
+      return results.find((s: SummonSearchResult) => s.name?.en === name || s.name?.ja === name) || null
     } catch {
       return null
     }
@@ -236,15 +272,15 @@
     }
   }
 
-  let _weaponStatModCache: Record<string, any> | null = null
+  let _weaponStatModCache: Record<string, WeaponStatModifier> | null = null
   async function fetchWeaponStatModifiers() {
     if (_weaponStatModCache) return _weaponStatModCache
     try {
       const apiUrl = await getApiUrl('/weapon_stat_modifiers')
       const response = await fetch(apiUrl)
       if (!response.ok) return null
-      const modifiers = await response.json()
-      _weaponStatModCache = {} as Record<string, any>
+      const modifiers = await response.json() as Array<{ slug: string; name_en: string; name_jp: string; suffix?: string }>
+      _weaponStatModCache = {} as Record<string, WeaponStatModifier>
       for (const mod of modifiers) {
         _weaponStatModCache[mod.slug] = {
           nameEn: mod.name_en,
@@ -284,7 +320,7 @@
   async function autoSuggestRaid(weaponCount: number, characterCount: number) {
     const response = await fetchRaidGroups()
     if (response.error || !response.data) return
-    const groups = response.data as any[]
+    const groups = response.data as RaidGroup[]
     let suggested = null
 
     if (weaponCount === 13 && characterCount === 8) {
@@ -300,9 +336,9 @@
     }
   }
 
-  function findRaidBySlug(groups: any[], slug: string) {
+  function findRaidBySlug(groups: RaidGroup[], slug: string) {
     for (const group of groups) {
-      const raid = (group.raids || []).find((r: any) => r.slug === slug)
+      const raid = (group.raids || []).find((r) => r.slug === slug)
       if (raid) return { ...raid, group }
     }
     return null
@@ -340,7 +376,7 @@
     {#if app.detailData}
       {#if isParty}
         <PartyDetail
-          data={app.detailData}
+          data={app.detailData as Record<string, unknown>}
           {friendSummon}
           {weaponKeyMap}
           {jobSkillSlugs}
@@ -348,9 +384,9 @@
           {simplePortraits}
         />
       {:else if isDatabase}
-        <DatabaseDetail dataType={dataType} data={app.detailData} />
+        <DatabaseDetail dataType={dataType} data={app.detailData as Record<string, unknown>} />
       {:else if isCharStats}
-        <CharacterStatsList data={app.detailData as Record<string, any>} />
+        <CharacterStatsList data={app.detailData as Record<string, Record<string, unknown>>} />
       {:else if hasNames}
         <ItemList
           items={filteredItems}

--- a/src/components/detail/DetailView.svelte
+++ b/src/components/detail/DetailView.svelte
@@ -12,6 +12,7 @@
     toArray
   } from '../../lib/detail-helpers.js'
   import { getCachedData, fetchRaidGroups } from '../../lib/services/chrome-messages.js'
+  import { translateError } from '../../lib/i18n.js'
 
   import type { RawGameItem } from '../../lib/detail-helpers.js'
   import type { RaidGroup } from '../../lib/types/messages.js'
@@ -185,7 +186,7 @@
   async function loadDetailData(dt: string) {
     const response = await getCachedData(dt)
     if (response.error) {
-      app.showToast(response.error)
+      app.showToast(translateError(response.error))
       return
     }
 

--- a/src/components/detail/DetailView.svelte
+++ b/src/components/detail/DetailView.svelte
@@ -192,8 +192,9 @@
     app.detailData = response.data
 
     // Get auth for simplePortraits
-    const { gbAuth } = await chrome.storage.local.get('gbAuth')
-    simplePortraits = gbAuth?.simplePortraits || false
+    const authResult = await chrome.storage.local.get('gbAuth')
+    const gbAuth = authResult.gbAuth as Record<string, unknown> | undefined
+    simplePortraits = (gbAuth?.simplePortraits as boolean) || false
 
     if (dt.startsWith('party_')) {
       await loadPartySupplementary(response.data as PartyDeckData)

--- a/src/components/detail/character-stats/CharacterStatsList.svelte
+++ b/src/components/detail/character-stats/CharacterStatsList.svelte
@@ -10,15 +10,33 @@
   } from '../../../lib/mastery.js'
   import * as m from '../../../paraglide/messages.js'
 
+  interface MasteryModifier {
+    modifier: number
+    strength: number | string
+    typeName?: string
+  }
+
+  interface CharacterStatsEntry {
+    masterId?: string
+    masterName?: string
+    element?: string
+    timestamp?: number
+    awakening?: { typeName?: string; level?: number } | null
+    perpetuity?: boolean
+    rings?: MasteryModifier[]
+    earring?: MasteryModifier | null
+    perpetuityBonuses?: MasteryModifier[]
+  }
+
   interface Props {
-    data: Record<string, any>
+    data: Record<string, CharacterStatsEntry>
   }
 
   let { data }: Props = $props()
 
   let characters = $derived.by(() => {
     const chars = Object.values(data)
-    return chars.sort((a: any, b: any) => (b.timestamp || 0) - (a.timestamp || 0))
+    return chars.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))
   })
 
   const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"/></svg>`
@@ -26,7 +44,7 @@
   // Initialize all items as selected
   $effect(() => {
     if (characters.length > 0 && app.selectedItems.size === 0) {
-      app.selectedItems = new Set(characters.map((_: any, i: number) => i))
+      app.selectedItems = new Set(characters.map((_, i) => i))
     }
   })
 
@@ -41,26 +59,26 @@
     app.selectedItems = next
   }
 
-  function getRingLines(char: any): string[] {
+  function getRingLines(char: CharacterStatsEntry): string[] {
     if (!char.rings || char.rings.length === 0) return []
     return char.rings
-      .map((ring: any) => formatModifier(ring, OVER_MASTERY_NAMES))
-      .filter(Boolean)
+      .map((ring) => formatModifier(ring, OVER_MASTERY_NAMES))
+      .filter((line): line is string => line !== null)
   }
 
-  function getEarringLine(char: any): string | null {
+  function getEarringLine(char: CharacterStatsEntry): string | null {
     if (!char.earring) return null
     return formatModifier(char.earring, AETHERIAL_NAMES)
   }
 
-  function getPerpetBonusLines(char: any): string[] {
+  function getPerpetBonusLines(char: CharacterStatsEntry): string[] {
     if (!char.perpetuityBonuses || char.perpetuityBonuses.length === 0) return []
     return char.perpetuityBonuses
-      .map((b: any) => formatPerpetuityBonus(b))
-      .filter(Boolean)
+      .map((b) => formatPerpetuityBonus(b))
+      .filter((line): line is string => line !== null)
   }
 
-  function hasStats(char: any): boolean {
+  function hasStats(char: CharacterStatsEntry): boolean {
     return !!(
       char.awakening ||
       char.perpetuity ||

--- a/src/components/detail/database/DatabaseDetail.svelte
+++ b/src/components/detail/database/DatabaseDetail.svelte
@@ -6,14 +6,33 @@
     renderSummonStats
   } from '../../../lib/detail-helpers.js'
 
-  interface Props {
-    dataType: string
-    data: any
+  interface DatabaseItemData {
+    id?: string
+    name?: string
+    attribute?: string | number
+    element?: string | number
+    specialty_weapon?: Array<string | number>
+    master?: {
+      id?: string
+      name?: string
+      attribute?: string | number
+      element?: string | number
+      specialty_weapon?: Array<string | number>
+      [key: string]: unknown
+    }
+    param?: Record<string, unknown>
+    [key: string]: unknown
   }
 
-  let { dataType, data }: Props = $props()
+  interface Props {
+    dataType: string
+    data: Record<string, unknown>
+  }
 
-  let id = $derived(data?.id || data?.master?.id)
+  let { dataType, data: rawData }: Props = $props()
+
+  let data = $derived(rawData as DatabaseItemData)
+  let id = $derived(data?.id || data?.master?.id || '')
   let name = $derived(data?.name || data?.master?.name || 'Unknown')
   let element = $derived(
     data?.attribute || data?.element || data?.master?.attribute || data?.master?.element
@@ -42,14 +61,15 @@
   })
 
   let statsHtml = $derived.by(() => {
+    const item = data as import('../../../lib/detail-helpers.js').RawGameItem
     if (dataType.startsWith('detail_npc')) {
-      return renderCharacterStats(data, name, id, element, proficiencies)
+      return renderCharacterStats(item, name, id, element, proficiencies)
     }
     if (dataType.startsWith('detail_weapon')) {
-      return renderWeaponStats(data, name, id, element, proficiencies[0])
+      return renderWeaponStats(item, name, id, element, proficiencies[0])
     }
     if (dataType.startsWith('detail_summon')) {
-      return renderSummonStats(data, name, id, element)
+      return renderSummonStats(item, name, id, element)
     }
     return ''
   })

--- a/src/components/detail/items/ItemGrid.svelte
+++ b/src/components/detail/items/ItemGrid.svelte
@@ -6,13 +6,21 @@
   import { getCollectionIds } from '../../../lib/services/chrome-messages.js'
   import * as m from '../../../paraglide/messages.js'
   import { onMount } from 'svelte'
+  import type { RawGameItem } from '../../../lib/detail-helpers.js'
+
+  interface WeaponStatModifier {
+    nameEn?: string
+    nameJp?: string
+    suffix?: string
+    [key: string]: unknown
+  }
 
   interface Props {
-    items: Array<{ item: any; originalIndex: number }>
+    items: Array<{ item: RawGameItem; originalIndex: number }>
     dataType: string
     isCollection: boolean
     simplePortraits?: boolean
-    weaponStatModifiers?: Record<string, any> | null
+    weaponStatModifiers?: Record<string, WeaponStatModifier> | null
   }
 
   let { items, dataType, isCollection, simplePortraits = false, weaponStatModifiers = null }: Props = $props()
@@ -26,7 +34,7 @@
 
   const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"/></svg>`
 
-  function getOwnershipId(item: any): string {
+  function getOwnershipId(item: RawGameItem): string {
     if (isCharacterType) return item.master?.id?.toString() || ''
     if (dataType.includes('artifact')) return item.id?.toString() || ''
     return item.param?.id?.toString() || ''
@@ -62,7 +70,7 @@
     app.selectedItems = selected
   }
 
-  function isOwned(item: any): boolean {
+  function isOwned(item: RawGameItem): boolean {
     const id = getOwnershipId(item)
     return id ? ownedIds.has(id) : false
   }
@@ -72,15 +80,14 @@
     try {
       const response = await getCollectionIds()
       if (response.error) return
-      const data = response.data as any
       if (dataType.includes('weapon') || dataType.startsWith('stash_weapon')) {
-        ownedIds = new Set(data?.weapons || [])
+        ownedIds = new Set(response.weapons || [])
       } else if (dataType.includes('summon') || dataType.startsWith('stash_summon')) {
-        ownedIds = new Set(data?.summons || [])
+        ownedIds = new Set(response.summons || [])
       } else if (dataType.includes('artifact')) {
-        ownedIds = new Set(data?.artifacts || [])
+        ownedIds = new Set(response.artifacts || [])
       } else if (isCharacterType) {
-        ownedIds = new Set(data?.characters || [])
+        ownedIds = new Set(response.characters || [])
       }
 
       // Uncheck owned items

--- a/src/components/detail/items/ItemGrid.svelte
+++ b/src/components/detail/items/ItemGrid.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
   import { app } from '../../../lib/state/app.svelte.js'
-  import { getItemImageUrl, getGridClass, getCharacterModifiers, getWeaponModifiers, isWeaponOrSummonCollection, resolveAwakeningIcon, resolveAugmentIcon, buildAxTooltip } from '../../../lib/detail-helpers.js'
+  import { getItemImageUrl, getGridClass, getCharacterModifiers, getWeaponModifiers, isWeaponOrSummonCollection, resolveAwakeningIcon, resolveAugmentIcon, buildAxTooltip, type WeaponStatModifier } from '../../../lib/detail-helpers.js'
   import { getImageUrl } from '../../../lib/constants.js'
   import { getLocale } from '../../../lib/i18n.js'
   import { getCollectionIds } from '../../../lib/services/chrome-messages.js'
   import * as m from '../../../paraglide/messages.js'
   import { onMount } from 'svelte'
   import type { RawGameItem } from '../../../lib/detail-helpers.js'
-
-  interface WeaponStatModifier {
-    nameEn?: string
-    nameJp?: string
-    suffix?: string
-    [key: string]: unknown
-  }
 
   interface Props {
     items: Array<{ item: RawGameItem; originalIndex: number }>

--- a/src/components/detail/items/ItemList.svelte
+++ b/src/components/detail/items/ItemList.svelte
@@ -4,9 +4,10 @@
   import { getCollectionIds } from '../../../lib/services/chrome-messages.js'
   import * as m from '../../../paraglide/messages.js'
   import { onMount } from 'svelte'
+  import type { RawGameItem } from '../../../lib/detail-helpers.js'
 
   interface Props {
-    items: Array<{ item: any; originalIndex: number }>
+    items: Array<{ item: RawGameItem; originalIndex: number }>
     dataType: string
     isCollection: boolean
     simplePortraits?: boolean
@@ -21,7 +22,7 @@
 
   const CHECK_ICON = `<svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.7139 4.04764C13.14 3.52854 13.0837 2.74594 12.5881 2.29964C12.0925 1.85335 11.3453 1.91237 10.9192 2.43147L5.28565 9.94404L3.02018 7.32366C2.55804 6.83959 1.80875 6.83959 1.34661 7.32366C0.884464 7.80772 0.884464 8.59255 1.34661 9.07662L4.50946 12.6369C4.9716 13.121 5.72089 13.121 6.18303 12.6369C6.2359 12.5816 6.28675 12.5271 6.33575 12.4674L12.7139 4.04764Z"/></svg>`
 
-  function getOwnershipId(item: any): string {
+  function getOwnershipId(item: RawGameItem): string {
     if (isCharacterType) return item.master?.id?.toString() || ''
     if (isArtifactType) return item.id?.toString() || ''
     return item.param?.id?.toString() || ''
@@ -41,7 +42,7 @@
     app.manuallyUnchecked = unchecked
   }
 
-  function isOwned(item: any): boolean {
+  function isOwned(item: RawGameItem): boolean {
     const id = getOwnershipId(item)
     return id ? ownedIds.has(id) : false
   }
@@ -51,15 +52,14 @@
     try {
       const response = await getCollectionIds()
       if (response.error) return
-      const data = response.data as any
       if (dataType.includes('weapon') || dataType.startsWith('stash_weapon')) {
-        ownedIds = new Set(data?.weapons || [])
+        ownedIds = new Set(response.weapons || [])
       } else if (dataType.includes('summon') || dataType.startsWith('stash_summon')) {
-        ownedIds = new Set(data?.summons || [])
+        ownedIds = new Set(response.summons || [])
       } else if (isArtifactType) {
-        ownedIds = new Set(data?.artifacts || [])
+        ownedIds = new Set(response.artifacts || [])
       } else if (isCharacterType) {
-        ownedIds = new Set(data?.characters || [])
+        ownedIds = new Set(response.characters || [])
       }
 
       if (ownedIds.size > 0) {

--- a/src/components/detail/party/PartyDetail.svelte
+++ b/src/components/detail/party/PartyDetail.svelte
@@ -14,17 +14,74 @@
   } from '../../../lib/game-data.js'
   import * as m from '../../../paraglide/messages.js'
 
+  interface RawPartyItem {
+    id?: string
+    master?: { id?: string; name?: string; image?: string; [key: string]: unknown }
+    param?: {
+      id?: string
+      evolution?: number
+      phase?: number
+      style?: string
+      image_id?: string
+      has_npcaugment_constant?: boolean
+      npc_arousal_form?: string
+      [key: string]: unknown
+    }
+    [key: string]: unknown
+  }
+
+  interface SummonSearchResult {
+    granblue_id?: string
+    imageSuffix?: string
+    name?: { en?: string; ja?: string }
+  }
+
+  interface WeaponStatModifier {
+    nameEn?: string
+    nameJp?: string
+    suffix?: string
+    [key: string]: unknown
+  }
+
+  interface BulletEntry {
+    bullet_id?: string
+    name?: string
+    [key: string]: unknown
+  }
+
+  interface PartyData {
+    deck?: {
+      pc?: {
+        job?: { master?: { id?: string; name?: string; image?: string } }
+        weapons?: Record<string, RawPartyItem | null>
+        summons?: Record<string, RawPartyItem | null>
+        sub_summons?: Record<string, RawPartyItem | null>
+        damage_info?: { summon_name?: string }
+        set_action?: Array<{ name: string }>
+        familiar_id?: string
+        shield_id?: string
+        quick_user_summon_id?: string
+        [key: string]: unknown
+      }
+      npc?: Record<string, RawPartyItem | null>
+      name?: string
+      [key: string]: unknown
+    }
+    bullet_info?: { set_bullets?: Record<string, BulletEntry> }
+    [key: string]: unknown
+  }
+
   interface Props {
-    data: any
-    friendSummon?: any
+    data: Record<string, unknown>
+    friendSummon?: SummonSearchResult | null
     weaponKeyMap?: Record<string, string> | null
     jobSkillSlugs?: Record<string, string>
-    weaponStatModifiers?: Record<string, any> | null
+    weaponStatModifiers?: Record<string, WeaponStatModifier> | null
     simplePortraits?: boolean
   }
 
   let {
-    data,
+    data: rawData,
     friendSummon = null,
     weaponKeyMap = null,
     jobSkillSlugs = {},
@@ -32,16 +89,17 @@
     simplePortraits = false
   }: Props = $props()
 
-  let deck = $derived(data?.deck || {})
-  let pc = $derived(deck.pc || {})
-  let job = $derived(pc.job)
-  let characters = $derived(toArray(deck.npc).filter(Boolean))
-  let weapons = $derived(toArray(pc.weapons).filter(Boolean))
-  let summons = $derived(toArray(pc.summons).filter(Boolean))
-  let subSummons = $derived(toArray(pc.sub_summons).filter(Boolean))
-  let accessoryIds = $derived([pc.familiar_id, pc.shield_id].filter(Boolean))
-  let quickSummonId = $derived(pc.quick_user_summon_id)
-  let setAction = $derived(pc.set_action || [])
+  let data = $derived(rawData as PartyData)
+  let deck = $derived(data?.deck)
+  let pc = $derived(deck?.pc)
+  let job = $derived(pc?.job)
+  let characters = $derived(toArray(deck?.npc).filter(Boolean) as RawPartyItem[])
+  let weapons = $derived(toArray(pc?.weapons).filter(Boolean) as RawPartyItem[])
+  let summons = $derived(toArray(pc?.summons).filter(Boolean) as RawPartyItem[])
+  let subSummons = $derived(toArray(pc?.sub_summons).filter(Boolean) as RawPartyItem[])
+  let accessoryIds = $derived([pc?.familiar_id, pc?.shield_id].filter(Boolean) as string[])
+  let quickSummonId = $derived(pc?.quick_user_summon_id)
+  let setAction = $derived(pc?.set_action || [])
 
   let mainWeapon = $derived(weapons[0])
   let gridWeapons = $derived(weapons.slice(1))
@@ -49,15 +107,15 @@
   let allSubSummons = $derived([...summons.slice(1), ...subSummons])
 
   let bulletInfo = $derived(data?.bullet_info?.set_bullets)
-  let bullets = $derived.by(() => {
+  let bullets = $derived.by((): BulletEntry[] => {
     if (!bulletInfo) return []
     return Object.entries(bulletInfo)
       .filter(([key]) => key.startsWith('bullet_'))
-      .map(([, bullet]) => bullet as any)
-      .filter((b) => b && b.bullet_id)
+      .map(([, bullet]) => bullet)
+      .filter((b): b is BulletEntry => !!b && !!b.bullet_id)
   })
 
-  function getCharImageSuffix(item: any): string {
+  function getCharImageSuffix(item: RawPartyItem): string {
     if (item.param?.style === '2') return '_01_style'
     const evolution = item.param?.evolution
     const phase = item.param?.phase
@@ -67,7 +125,7 @@
     return '_01'
   }
 
-  function getImageSuffix(item: any): string {
+  function getImageSuffix(item: RawPartyItem): string {
     const imageId = item.param?.image_id
     if (!imageId) return ''
     const id = item.master?.id || item.param?.id || item.id
@@ -75,9 +133,9 @@
     return imageId.slice(String(id).length)
   }
 
-  function getCharModifiers(item: any): { awakening: string | null; perpetuity: boolean } {
+  function getCharModifiers(item: RawPartyItem): { awakening: string | null; perpetuity: boolean } {
     const arousalForm = item.param?.npc_arousal_form
-    const awakeningSlug = arousalForm ? CHARACTER_AWAKENING_MAPPING[arousalForm] : null
+    const awakeningSlug = arousalForm ? CHARACTER_AWAKENING_MAPPING[Number(arousalForm)] : null
     const hasPerpetuit = !!item.param?.has_npcaugment_constant
     return {
       awakening: awakeningSlug && awakeningSlug !== 'character-balanced' ? awakeningSlug : null,
@@ -85,8 +143,8 @@
     }
   }
 
-  function resolveSummonId(item: any): string {
-    return resolveForgedSummonId(item.master?.id || item.param?.id || item.id)
+  function resolveSummonId(item: RawPartyItem): string {
+    return resolveForgedSummonId(item.master?.id || item.param?.id || item.id || '')
   }
 </script>
 

--- a/src/components/detail/party/PartyDetail.svelte
+++ b/src/components/detail/party/PartyDetail.svelte
@@ -5,7 +5,8 @@
     getWeaponModifiers,
     resolveAwakeningIcon,
     resolveAugmentIcon,
-    buildAxTooltip
+    buildAxTooltip,
+    type WeaponStatModifier
   } from '../../../lib/detail-helpers.js'
   import { getLocale } from '../../../lib/i18n.js'
   import {
@@ -34,13 +35,6 @@
     granblue_id?: string
     imageSuffix?: string
     name?: { en?: string; ja?: string }
-  }
-
-  interface WeaponStatModifier {
-    nameEn?: string
-    nameJp?: string
-    suffix?: string
-    [key: string]: unknown
   }
 
   interface BulletEntry {
@@ -217,8 +211,8 @@
         {#if mainWeapon}
           {@const mainId = mainWeapon.master?.id || mainWeapon.param?.id || mainWeapon.id}
           {@const mainSuffix = getImageSuffix(mainWeapon)}
+          {@const mainMods = getWeaponModifiers(mainWeapon, weaponKeyMap)}
           <div class="weapon-mainhand">
-            {@const mainMods = getWeaponModifiers(mainWeapon, weaponKeyMap)}
             {#if mainMods.awakening || mainMods.axSkill || mainMods.befoulment || mainMods.weaponKeys.length > 0}
               <div class="weapon-modifiers">
                 {#if mainMods.awakening}
@@ -248,8 +242,8 @@
           {#each gridWeapons as item}
             {@const id = item.master?.id || item.param?.id || item.id}
             {@const suffix = getImageSuffix(item)}
+            {@const wMods = getWeaponModifiers(item, weaponKeyMap)}
             <div class="grid-item">
-              {@const wMods = getWeaponModifiers(item, weaponKeyMap)}
               {#if wMods.awakening || wMods.axSkill || wMods.befoulment || wMods.weaponKeys.length > 0}
                 <div class="weapon-modifiers">
                   {#if wMods.awakening}

--- a/src/components/detail/party/PartyMeta.svelte
+++ b/src/components/detail/party/PartyMeta.svelte
@@ -9,7 +9,7 @@
     const name =
       typeof raid.name === 'string'
         ? raid.name
-        : (raid.name as any)?.en ?? 'Unknown'
+        : (raid.name as { en?: string })?.en ?? 'Unknown'
     const level = raid.level ? ` Lv. ${raid.level}` : ''
     return `${name}${level}`
   })
@@ -24,7 +24,7 @@
     const playlists = app.selectedPlaylists
     if (!playlists || playlists.length === 0) return m.playlist_label()
     if (playlists.length === 1) return playlists[0]!.title
-    return m.count_playlists({ count: playlists.length } as any)
+    return m.count_playlists({ count: playlists.length })
   })
 
   let visibilityLabel = $derived.by(() => {

--- a/src/components/login/WarningCard.svelte
+++ b/src/components/login/WarningCard.svelte
@@ -5,6 +5,7 @@
   function acknowledge() {
     chrome.storage.local.set({ noticeAcknowledged: true })
     app.noticeAcknowledged = true
+    app.showingDisclaimer = false
   }
 </script>
 

--- a/src/components/main/CacheItemRow.svelte
+++ b/src/components/main/CacheItemRow.svelte
@@ -12,7 +12,7 @@
 
   const isStash = $derived(dataType.startsWith('stash_'))
   const displayName = $derived(
-    (status as any).partyName || status.displayName
+    status.partyName || status.displayName
   )
 </script>
 

--- a/src/components/main/CollectionPanel.svelte
+++ b/src/components/main/CollectionPanel.svelte
@@ -44,7 +44,7 @@
     {:else}
       {#each collectionTypes() as dataType (dataType)}
         <CacheItemRow
-          status={app.cachedStatus[dataType]}
+          status={app.cachedStatus[dataType]!}
           {dataType}
           onclick={() => openDetail(dataType)}
         />

--- a/src/components/main/CollectionPanel.svelte
+++ b/src/components/main/CollectionPanel.svelte
@@ -19,8 +19,8 @@
     const all = [...staticTypes, ...stashTypes]
 
     all.sort((a, b) => {
-      const aTime = (app.cachedStatus[a] as any)?.lastUpdated || 0
-      const bTime = (app.cachedStatus[b] as any)?.lastUpdated || 0
+      const aTime = app.cachedStatus[a]?.timestamp || 0
+      const bTime = app.cachedStatus[b]?.timestamp || 0
       return bTime - aTime
     })
 

--- a/src/components/main/DatabasePanel.svelte
+++ b/src/components/main/DatabasePanel.svelte
@@ -36,7 +36,7 @@
     {:else}
       {#each databaseTypes as dataType (dataType)}
         <CacheItemRow
-          status={app.cachedStatus[dataType]}
+          status={app.cachedStatus[dataType]!}
           {dataType}
           onclick={() => openDetail(dataType)}
         />

--- a/src/components/main/DatabasePanel.svelte
+++ b/src/components/main/DatabasePanel.svelte
@@ -13,8 +13,8 @@
           app.cachedStatus[type]?.available
       )
       .sort((a, b) => {
-        const aTime = (app.cachedStatus[a] as any)?.lastUpdated || 0
-        const bTime = (app.cachedStatus[b] as any)?.lastUpdated || 0
+        const aTime = app.cachedStatus[a]?.timestamp || 0
+        const bTime = app.cachedStatus[b]?.timestamp || 0
         return bTime - aTime
       })
   )

--- a/src/components/main/MainView.svelte
+++ b/src/components/main/MainView.svelte
@@ -16,34 +16,44 @@
   onMount(async () => {
     // Check for extension updates
     const versionResponse = await checkExtensionVersion()
-    if ((versionResponse as any)?.isOutdated) {
-      latestVersion = (versionResponse as any).latest
+    if (versionResponse?.isOutdated && versionResponse.latest) {
+      latestVersion = versionResponse.latest
     }
 
     // Refresh user info
-    const gbAuth = app.auth as any
-    if (gbAuth?.access_token) {
+    if (app.auth?.access_token) {
       try {
-        const userInfo = (await fetchUserInfo(gbAuth.access_token)) as any
+        const userInfo = await fetchUserInfo(app.auth.access_token) as {
+          avatar?: { picture?: string; element?: string }
+          display_name?: string
+          language?: string
+          role?: number
+          simple_portraits?: boolean
+          default_import_visibility?: number
+          has_crew?: boolean
+          crew_name?: string
+          gamertag?: string
+          username?: string
+        }
 
         const updated = {
-          ...gbAuth,
+          ...app.auth,
           avatar: userInfo.avatar,
-          displayName: userInfo.display_name || null,
-          language: userInfo.language || gbAuth.language,
-          role: userInfo.role ?? gbAuth.role,
+          displayName: userInfo.display_name || undefined,
+          language: userInfo.language || app.auth.language,
+          role: userInfo.role ?? app.auth.role,
           simplePortraits: userInfo.simple_portraits || false,
           defaultImportVisibility:
             userInfo.default_import_visibility ??
-            gbAuth.defaultImportVisibility,
+            app.auth.defaultImportVisibility,
           hasCrew: !!(
             userInfo.has_crew ||
             userInfo.crew_name ||
             userInfo.gamertag
           ),
           user: {
-            ...gbAuth.user,
-            username: userInfo.username || gbAuth.user?.username
+            ...app.auth.user,
+            username: userInfo.username || app.auth.user?.username
           }
         }
 
@@ -57,7 +67,7 @@
 
   // Apply element color to body when auth changes
   $effect(() => {
-    const element = (app.auth as any)?.avatar?.element
+    const element = app.auth?.avatar?.element
     document.body.classList.remove(...ELEMENT_CLASSES)
     if (element && (ELEMENT_CLASSES as readonly string[]).includes(element)) {
       document.body.classList.add(element)

--- a/src/components/main/PartyPanel.svelte
+++ b/src/components/main/PartyPanel.svelte
@@ -28,7 +28,7 @@
     {:else}
       {#each partyTypes as dataType (dataType)}
         <CacheItemRow
-          status={app.cachedStatus[dataType]}
+          status={app.cachedStatus[dataType]!}
           {dataType}
           onclick={() => openDetail(dataType)}
         />

--- a/src/components/main/PartyPanel.svelte
+++ b/src/components/main/PartyPanel.svelte
@@ -9,8 +9,8 @@
         (type) => type.startsWith('party_') && app.cachedStatus[type]?.available
       )
       .sort((a, b) => {
-        const aTime = (app.cachedStatus[a] as any)?.lastUpdated || 0
-        const bTime = (app.cachedStatus[b] as any)?.lastUpdated || 0
+        const aTime = app.cachedStatus[a]?.timestamp || 0
+        const bTime = app.cachedStatus[b]?.timestamp || 0
         return bTime - aTime
       })
   )

--- a/src/components/main/TabNav.svelte
+++ b/src/components/main/TabNav.svelte
@@ -4,8 +4,8 @@
   import { getImageUrl } from '../../lib/constants.js'
 
   const avatarUrl = $derived(
-    (app.auth as any)?.avatar?.picture
-      ? getImageUrl(`profile/${(app.auth as any).avatar.picture}@2x.png`)
+    app.auth?.avatar?.picture
+      ? getImageUrl(`profile/${app.auth.avatar.picture}@2x.png`)
       : getImageUrl('profile/npc@2x.png')
   )
 

--- a/src/components/modals/SyncModal.svelte
+++ b/src/components/modals/SyncModal.svelte
@@ -40,7 +40,7 @@
     if (res.error) {
       app.showToast(res.error)
     } else {
-      app.showToast(m.sync_result({ total: (res.data?.created ?? 0) + (res.data?.updated ?? 0) }))
+      app.showToast(m.sync_result({ total: (res.created ?? 0) + (res.updated ?? 0) }))
     }
   }
 </script>

--- a/src/components/modals/SyncModal.svelte
+++ b/src/components/modals/SyncModal.svelte
@@ -3,6 +3,7 @@
   import * as m from '../../paraglide/messages.js'
   import { getImageUrl } from '../../lib/constants.js'
   import { previewSyncDeletions, syncCollection } from '../../lib/services/chrome-messages.js'
+  import { translateError } from '../../lib/i18n.js'
 
   function getSyncPreviewImageUrl(granblueId: string | undefined): string {
     if (!granblueId) return ''
@@ -38,7 +39,7 @@
     app.syncPreview = null
 
     if (res.error) {
-      app.showToast(res.error)
+      app.showToast(translateError(res.error))
     } else {
       app.showToast(m.sync_result({ total: (res.created ?? 0) + (res.updated ?? 0) }))
     }

--- a/src/components/pickers/PlaylistPicker.svelte
+++ b/src/components/pickers/PlaylistPicker.svelte
@@ -34,7 +34,9 @@
 
   async function loadPlaylists() {
     const res = await fetchUserPlaylists()
-    if (!res.error) playlists = res.data?.results ?? res.data ?? []
+    if (!res.error && res.data) {
+      playlists = (Array.isArray(res.data) ? res.data : res.data.results ?? []) as Playlist[]
+    }
   }
 
   function close() {
@@ -99,7 +101,7 @@
       return
     }
 
-    const newPlaylist = res.data?.playlist ?? res.data
+    const newPlaylist = res.data
     if (newPlaylist) {
       if (!newPlaylist.title) newPlaylist.title = createTitle.trim()
       app.selectedPlaylists = [...app.selectedPlaylists, { id: String(newPlaylist.id), title: newPlaylist.title }]

--- a/src/components/pickers/PlaylistPicker.svelte
+++ b/src/components/pickers/PlaylistPicker.svelte
@@ -2,6 +2,7 @@
   import { app } from '../../lib/state/app.svelte.js'
   import * as m from '../../paraglide/messages.js'
   import { fetchUserPlaylists, createPlaylist } from '../../lib/services/chrome-messages.js'
+  import { translateError } from '../../lib/i18n.js'
 
   interface Playlist {
     id: string | number
@@ -97,7 +98,7 @@
     creating = false
 
     if (res.error) {
-      createError = res.error
+      createError = translateError(res.error)
       return
     }
 

--- a/src/components/pickers/RaidPicker.svelte
+++ b/src/components/pickers/RaidPicker.svelte
@@ -107,10 +107,10 @@
   })
 
   function selectRaid(raid: Raid, group: RaidGroup) {
-    if (app.selectedRaid && (app.selectedRaid as any).id === raid.id) {
+    if (app.selectedRaid && app.selectedRaid.id === raid.id) {
       app.selectedRaid = null
     } else {
-      app.selectedRaid = { ...raid, group } as any
+      app.selectedRaid = { ...raid, group }
     }
     close()
   }
@@ -162,7 +162,7 @@
             </div>
             <div class="raid-group-raids">
               {#each group.raids ?? [] as raid}
-                {@const isSelected = app.selectedRaid !== null && (app.selectedRaid as any).id === raid.id}
+                {@const isSelected = app.selectedRaid !== null && app.selectedRaid.id === raid.id}
                 <button type="button" class="raid-item" class:selected={isSelected} onclick={() => selectRaid(raid, group)}>
                   {#if getRaidImageUrl(raid)}
                     <img src={getRaidImageUrl(raid)} alt="" class="raid-item-icon" onerror={(e: Event) => { (e.target as HTMLElement).style.display = 'none' }} />

--- a/src/components/profile/ProfilePopover.svelte
+++ b/src/components/profile/ProfilePopover.svelte
@@ -98,9 +98,7 @@
 
   function handleShowDisclaimer() {
     app.profilePopoverOpen = false
-    // TODO: Requires App.svelte to check a showingDisclaimer flag
-    // so the warning can overlay without logging the user out.
-    app.noticeAcknowledged = false
+    app.showingDisclaimer = true
   }
 
   function handlePopOut() {

--- a/src/components/profile/ProfilePopover.svelte
+++ b/src/components/profile/ProfilePopover.svelte
@@ -16,15 +16,15 @@
   let isPopupWindow = $state(false)
 
   const avatarUrl = $derived(
-    (app.auth as any)?.avatar?.picture
-      ? getImageUrl(`profile/${(app.auth as any).avatar.picture}@2x.png`)
+    app.auth?.avatar?.picture
+      ? getImageUrl(`profile/${app.auth.avatar.picture}@2x.png`)
       : getImageUrl('profile/npc@2x.png')
   )
 
   const username = $derived(
-    (app.auth as any)?.displayName ||
+    app.auth?.displayName ||
       app.auth?.username ||
-      (app.auth as any)?.user?.username ||
+      app.auth?.user?.username ||
       'User'
   )
 
@@ -33,7 +33,7 @@
 
   onMount(async () => {
     const siteUrl = await getSiteBaseUrl()
-    const user = (app.auth as any)?.user?.username
+    const user = app.auth?.user?.username
     if (user) profileUrl = `${siteUrl}/${user}`
 
     chrome.windows.getCurrent((win) => {

--- a/src/components/profile/ProfilePopover.svelte
+++ b/src/components/profile/ProfilePopover.svelte
@@ -36,7 +36,7 @@
     const user = app.auth?.user?.username
     if (user) profileUrl = `${siteUrl}/${user}`
 
-    chrome.windows.getCurrent((win) => {
+    chrome.windows.getCurrent((win: chrome.windows.Window) => {
       isPopupWindow = win.type === 'popup'
     })
   })
@@ -59,12 +59,13 @@
     app.cachedStatus = await getCacheStatus()
 
     // Persist to server
-    const { gbAuth } = await chrome.storage.local.get('gbAuth')
+    const result = await chrome.storage.local.get('gbAuth')
+    const gbAuth = result.gbAuth as Record<string, unknown> | undefined
     if (gbAuth?.access_token) {
       gbAuth.language = lang
       await chrome.storage.local.set({ gbAuth })
       try {
-        await updateUserLanguage(gbAuth.access_token, lang)
+        await updateUserLanguage(gbAuth.access_token as string, lang)
       } catch {
         // Silently fail -- local preference is saved anyway
       }

--- a/src/entrypoints/sidepanel/styles/_login.scss
+++ b/src/entrypoints/sidepanel/styles/_login.scss
@@ -80,6 +80,18 @@
   }
 }
 
+.disclaimer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-lg);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
 .login-language-switch {
   display: block;
   margin-top: 24px;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="chrome" />

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -47,7 +47,7 @@ async function authenticatedFetch(
   const response = await fetch(apiUrl, {
     method: options.method ?? 'GET',
     headers,
-    ...(options.body && { body: JSON.stringify(options.body) })
+    ...(options.body ? { body: JSON.stringify(options.body) } : {})
   })
 
   if (!response.ok) {

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -204,7 +204,12 @@ interface VersionCheckResult {
 
 initDebugger(handleInterceptedData)
 
-let collectionIdsCache: { weapons?: string[]; summons?: string[]; characters?: string[]; artifacts?: string[] } | null = null
+let collectionIdsCache: {
+  weapons?: string[]
+  summons?: string[]
+  characters?: string[]
+  artifacts?: string[]
+} | null = null
 let collectionIdsCacheTime = 0
 const COLLECTION_IDS_TTL_MS = 5 * 60 * 1000
 
@@ -720,9 +725,7 @@ chrome.runtime.onMessage.addListener(
         return true
 
       case 'clearCache':
-        handleClearCache(message.dataType).then(
-          sendResponse
-        )
+        handleClearCache(message.dataType).then(sendResponse)
         return true
 
       case 'getDebuggerStatus':
@@ -754,9 +757,7 @@ chrome.runtime.onMessage.addListener(
         return false
 
       case 'fetchRaidGroups':
-        fetchRaidGroups(message.forceRefresh).then(
-          sendResponse
-        )
+        fetchRaidGroups(message.forceRefresh).then(sendResponse)
         return true
 
       case 'fetchUserPlaylists':
@@ -765,7 +766,11 @@ chrome.runtime.onMessage.addListener(
 
       case 'createPlaylist':
         createPlaylist(
-          message.data as { title: string; description: string; visibility: number }
+          message.data as {
+            title: string
+            description: string
+            visibility: number
+          }
         ).then(sendResponse)
         return true
 
@@ -915,7 +920,10 @@ async function handleGetCachedData(
 
 async function handleGetCacheStatus(): Promise<CacheStatusResult> {
   const allStorage = await chrome.storage.local.get(null)
-  const status: Record<string, CacheStatusEntry | { attached: boolean; tabs: number[] }> = {}
+  const status: Record<
+    string,
+    CacheStatusEntry | { attached: boolean; tabs: number[] }
+  > = {}
   const now = Date.now()
 
   status._debugger = {
@@ -1459,7 +1467,13 @@ async function fetchRaidGroups(
   }
 }
 
-async function getCollectionIds(): Promise<{ error?: string; weapons?: string[]; summons?: string[]; characters?: string[]; artifacts?: string[] }> {
+async function getCollectionIds(): Promise<{
+  error?: string
+  weapons?: string[]
+  summons?: string[]
+  characters?: string[]
+  artifacts?: string[]
+}> {
   const now = Date.now()
   if (
     collectionIdsCache &&

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -188,7 +188,7 @@ async function handleInterceptedData(
         await cacheCharacterStats(
           'character_detail',
           d,
-          (d.master as Record<string, unknown>)?.id as string | undefined,
+          ((d.master as Record<string, unknown>)?.id as string) ?? null,
           timestamp,
           url
         )
@@ -286,7 +286,7 @@ async function cacheListPage(
   if (!cacheKey) return
 
   const result = await chrome.storage.local.get(cacheKey)
-  const existing: CachedListData = result[cacheKey] ?? {
+  const existing: CachedListData = (result[cacheKey] as CachedListData) ?? {
     pages: {},
     lastUpdated: null
   }
@@ -336,7 +336,11 @@ async function cacheCharacterStats(
     lastUpdated: number | null
     updates: Record<string, CharacterStatsEntry>
     characterCount?: number
-  } = result[CACHE_KEYS.character_stats!] ?? {
+  } = (result[CACHE_KEYS.character_stats!] as {
+    lastUpdated: number | null
+    updates: Record<string, CharacterStatsEntry>
+    characterCount?: number
+  }) ?? {
     lastUpdated: null,
     updates: {}
   }

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -896,18 +896,18 @@ async function handleGetCachedData(
     dataType.startsWith('stash_')
   ) {
     return {
-      data: cached.pages,
-      timestamp: cached.lastUpdated,
+      data: cached.pages as Record<string, unknown>,
+      timestamp: cached.lastUpdated as number,
       age,
       dataType,
-      pageCount: cached.pageCount,
-      totalItems: cached.totalItems
+      pageCount: cached.pageCount as number,
+      totalItems: cached.totalItems as number
     }
   }
 
   return {
-    data: cached.data,
-    timestamp: cached.timestamp,
+    data: cached.data as Record<string, unknown>,
+    timestamp: cached.timestamp as number,
     age,
     dataType
   }
@@ -950,13 +950,13 @@ async function handleGetCacheStatus(): Promise<CacheStatusResult> {
     } else if (type.startsWith('list_') || type.startsWith('collection_')) {
       status[type] = {
         available: !stale && (cached.pageCount as number) > 0,
-        pageCount: cached.pageCount ?? 0,
-        totalPages: cached.totalPages ?? null,
-        totalItems: cached.totalItems ?? 0,
+        pageCount: (cached.pageCount as number) ?? 0,
+        totalPages: (cached.totalPages as number | null) ?? null,
+        totalItems: (cached.totalItems as number) ?? 0,
         lastUpdated: timestamp,
         age,
         isStale: stale,
-        isComplete: cached.isComplete ?? false
+        isComplete: (cached.isComplete as boolean) ?? false
       }
     } else {
       status[type] = {
@@ -1001,12 +1001,12 @@ async function handleGetCacheStatus(): Promise<CacheStatusResult> {
     } else if (matchedPrefix.startsWith('stash_')) {
       status[dt] = {
         available: !stale && (c.pageCount as number) > 0,
-        pageCount: c.pageCount ?? 0,
-        totalItems: c.totalItems ?? 0,
+        pageCount: (c.pageCount as number) ?? 0,
+        totalItems: (c.totalItems as number) ?? 0,
         lastUpdated: timestamp,
         age,
         isStale: stale,
-        stashName: c.stashName ?? null
+        stashName: (c.stashName as string | null) ?? null
       }
     } else if (matchedPrefix.startsWith('detail_')) {
       status[dt] = {
@@ -1144,7 +1144,7 @@ async function uploadPartyData(
   const siteUrl = await getSiteBaseUrl()
   return {
     success: true,
-    shortcode: result.data!.shortcode,
+    shortcode: result.data!.shortcode as string,
     url: `${siteUrl}/teams/${result.data!.shortcode}`
   }
 }
@@ -1168,7 +1168,7 @@ async function uploadDetailData(
     `/import/${endpoint}?lang=${lang}`,
     data
   )
-  if (result.error) return result
+  if (result.error) return { error: result.error }
   return { success: true, ...result.data }
 }
 

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -102,13 +102,109 @@ interface UploadCollectionOptions {
   conflictResolutions?: unknown
 }
 
+// --- API response types ---
+
+interface ApiResult<T = Record<string, unknown>> {
+  error?: string
+  data?: T
+  auth?: AuthToken
+}
+
+interface UploadPartyResult {
+  success?: boolean
+  shortcode?: string
+  url?: string
+  error?: string
+}
+
+interface UploadDetailResult {
+  success?: boolean
+  error?: string
+  [key: string]: unknown
+}
+
+interface UploadCollectionResult {
+  success?: boolean
+  created?: number
+  updated?: number
+  skipped?: number
+  errors?: unknown[]
+  reconciliation?: unknown
+  error?: string
+}
+
+interface ConflictCheckResult {
+  conflicts?: unknown[]
+  error?: string
+}
+
+interface SyncPreviewResult {
+  willDelete?: unknown[]
+  count?: number
+  error?: string
+}
+
+interface CachedDataResult {
+  data?: Record<string, unknown> | Record<number, unknown>
+  error?: string
+  timestamp?: number
+  age?: number
+  dataType?: string
+  pageCount?: number
+  totalItems?: number
+  characterCount?: number
+}
+
+interface CacheStatusEntry {
+  available: boolean
+  lastUpdated?: number
+  age?: number
+  isStale?: boolean
+  pageCount?: number
+  totalPages?: number | null
+  totalItems?: number
+  isComplete?: boolean
+  characterCount?: number
+  partyId?: string
+  partyName?: string
+  stashName?: string | null
+  granblueId?: string
+  itemName?: string
+}
+
+interface CacheStatusResult {
+  _debugger: { attached: boolean; tabs: number[] }
+  [key: string]: CacheStatusEntry | { attached: boolean; tabs: number[] }
+}
+
+interface FetchPlaylistsResult {
+  data?: unknown
+  error?: string
+}
+
+interface FetchRaidGroupsResult {
+  data?: unknown
+  error?: string
+}
+
+interface CreatePlaylistResult {
+  data?: Record<string, unknown>
+  error?: string
+}
+
+interface VersionCheckResult {
+  isOutdated: boolean
+  current: string
+  latest: string
+}
+
 // ==========================================
 // INITIALIZATION
 // ==========================================
 
 initDebugger(handleInterceptedData)
 
-let collectionIdsCache: unknown = null
+let collectionIdsCache: { weapons?: string[]; summons?: string[]; characters?: string[]; artifacts?: string[] } | null = null
 let collectionIdsCacheTime = 0
 const COLLECTION_IDS_TTL_MS = 5 * 60 * 1000
 
@@ -550,11 +646,7 @@ function parseZenithMasteryData(
 // VERSION CHECK
 // ==========================================
 
-async function checkExtensionVersion(): Promise<{
-  isOutdated: boolean
-  current: string
-  latest: string
-} | null> {
+async function checkExtensionVersion(): Promise<VersionCheckResult | null> {
   try {
     const apiUrl = await getApiUrl('/version')
     const response = await fetch(apiUrl)
@@ -592,9 +684,25 @@ function compareVersions(a: string, b: string): number {
 // MESSAGE HANDLING
 // ==========================================
 
+interface BackgroundMessage {
+  action: string
+  dataType?: string
+  data?: unknown
+  raidId?: string
+  playlistIds?: string[]
+  name?: string
+  visibility?: number
+  shareWithCrew?: boolean
+  updateExisting?: boolean
+  isFullInventory?: boolean
+  reconcileDeletions?: boolean
+  conflictResolutions?: unknown
+  forceRefresh?: boolean
+}
+
 chrome.runtime.onMessage.addListener(
   (
-    message: Record<string, unknown>,
+    message: BackgroundMessage,
     _sender: chrome.runtime.MessageSender,
     sendResponse: (response?: unknown) => void
   ) => {
@@ -608,11 +716,11 @@ chrome.runtime.onMessage.addListener(
         return true
 
       case 'getCachedData':
-        handleGetCachedData(message.dataType as string).then(sendResponse)
+        handleGetCachedData(message.dataType!).then(sendResponse)
         return true
 
       case 'clearCache':
-        handleClearCache(message.dataType as string | undefined).then(
+        handleClearCache(message.dataType).then(
           sendResponse
         )
         return true
@@ -646,7 +754,7 @@ chrome.runtime.onMessage.addListener(
         return false
 
       case 'fetchRaidGroups':
-        fetchRaidGroups(message.forceRefresh as boolean | undefined).then(
+        fetchRaidGroups(message.forceRefresh).then(
           sendResponse
         )
         return true
@@ -657,29 +765,25 @@ chrome.runtime.onMessage.addListener(
 
       case 'createPlaylist':
         createPlaylist(
-          message.data as {
-            title: string
-            description: string
-            visibility: number
-          }
+          message.data as { title: string; description: string; visibility: number }
         ).then(sendResponse)
         return true
 
       case 'uploadPartyData':
         uploadPartyData(
           message.data,
-          message.raidId as string | undefined,
-          message.playlistIds as string[] | undefined,
-          message.name as string | undefined,
-          message.visibility as number | undefined,
-          message.shareWithCrew as boolean | undefined
+          message.raidId,
+          message.playlistIds,
+          message.name,
+          message.visibility,
+          message.shareWithCrew
         ).then(sendResponse)
         return true
 
       case 'uploadDetailData':
         uploadDetailData(
           message.data as Record<string, unknown>,
-          message.dataType as string
+          message.dataType!
         ).then(sendResponse)
         return true
 
@@ -690,20 +794,18 @@ chrome.runtime.onMessage.addListener(
       case 'checkConflicts':
         checkConflicts(
           message.data as Record<number, PageData>,
-          message.dataType as string
+          message.dataType!
         ).then(sendResponse)
         return true
 
       case 'uploadCollectionData':
         uploadCollectionData(
           message.data as Record<number, PageData>,
-          message.dataType as string,
+          message.dataType!,
           {
-            updateExisting: message.updateExisting as boolean | undefined,
-            isFullInventory: message.isFullInventory as boolean | undefined,
-            reconcileDeletions: message.reconcileDeletions as
-              | boolean
-              | undefined,
+            updateExisting: message.updateExisting,
+            isFullInventory: message.isFullInventory,
+            reconcileDeletions: message.reconcileDeletions,
             conflictResolutions: message.conflictResolutions
           }
         ).then(sendResponse)
@@ -712,7 +814,7 @@ chrome.runtime.onMessage.addListener(
       case 'previewSyncDeletions':
         previewSyncDeletions(
           message.data as Record<number, PageData>,
-          message.dataType as string
+          message.dataType!
         ).then(sendResponse)
         return true
 
@@ -738,7 +840,7 @@ chrome.runtime.onMessage.addListener(
 
 async function handleGetCachedData(
   dataType: string
-): Promise<Record<string, unknown>> {
+): Promise<CachedDataResult> {
   if (dataType === 'character_stats') {
     const result = await chrome.storage.local.get(CACHE_KEYS.character_stats)
     const cached = result[CACHE_KEYS.character_stats!] as
@@ -811,9 +913,9 @@ async function handleGetCachedData(
   }
 }
 
-async function handleGetCacheStatus(): Promise<Record<string, unknown>> {
+async function handleGetCacheStatus(): Promise<CacheStatusResult> {
   const allStorage = await chrome.storage.local.get(null)
-  const status: Record<string, unknown> = {}
+  const status: Record<string, CacheStatusEntry | { attached: boolean; tabs: number[] }> = {}
   const now = Date.now()
 
   status._debugger = {
@@ -918,7 +1020,7 @@ async function handleGetCacheStatus(): Promise<Record<string, unknown>> {
     }
   }
 
-  return status
+  return status as CacheStatusResult
 }
 
 async function handleClearCache(
@@ -990,11 +1092,7 @@ async function parseErrorResponse(response: Response): Promise<string> {
 async function authenticatedPost(
   endpoint: string,
   body: unknown
-): Promise<{
-  error?: string
-  data?: Record<string, unknown>
-  auth?: AuthToken
-}> {
+): Promise<ApiResult> {
   const auth = await getAuthToken()
   if (!auth) return { error: 'not_logged_in' }
 
@@ -1026,7 +1124,7 @@ async function uploadPartyData(
   name?: string,
   visibility?: number,
   shareWithCrew?: boolean
-): Promise<Record<string, unknown>> {
+): Promise<UploadPartyResult> {
   const body: Record<string, unknown> = { import: data }
   if (raidId) body.raid_id = raidId
   if (playlistIds && playlistIds.length > 0) body.playlist_ids = playlistIds
@@ -1054,7 +1152,7 @@ async function uploadPartyData(
 async function uploadDetailData(
   data: Record<string, unknown>,
   dataType: string
-): Promise<Record<string, unknown>> {
+): Promise<UploadDetailResult> {
   const endpoint = resolveEndpoint(dataType)
   if (!endpoint) return { error: `Unknown data type: ${dataType}` }
 
@@ -1126,7 +1224,7 @@ function extractFilterFromPages(
 async function previewSyncDeletions(
   pagesData: Record<number, PageData>,
   dataType: string
-): Promise<Record<string, unknown>> {
+): Promise<SyncPreviewResult> {
   const endpoint = resolveEndpoint(dataType)
   if (!endpoint) return { error: 'unknown_type' }
 
@@ -1141,17 +1239,17 @@ async function previewSyncDeletions(
       filter: activeFilter
     }
   )
-  if (result.error) return result
+  if (result.error) return { error: result.error }
   return {
-    willDelete: result.data!.will_delete ?? [],
-    count: result.data!.count ?? 0
+    willDelete: (result.data!.will_delete as unknown[]) ?? [],
+    count: (result.data!.count as number) ?? 0
   }
 }
 
 async function checkConflicts(
   pagesData: Record<number, PageData>,
   dataType: string
-): Promise<Record<string, unknown>> {
+): Promise<ConflictCheckResult> {
   const endpoint = resolveEndpoint(dataType)
   if (!endpoint) return { error: 'unknown_type' }
 
@@ -1162,15 +1260,15 @@ async function checkConflicts(
     `/collection/${endpoint}/check_conflicts`,
     { data: { list: allItems } }
   )
-  if (result.error) return result
-  return { conflicts: result.data!.conflicts ?? [] }
+  if (result.error) return { error: result.error }
+  return { conflicts: (result.data!.conflicts as unknown[]) ?? [] }
 }
 
 async function uploadCollectionData(
   pagesData: Record<number, PageData>,
   dataType: string,
   options: UploadCollectionOptions = {}
-): Promise<Record<string, unknown>> {
+): Promise<UploadCollectionResult> {
   const {
     updateExisting = false,
     isFullInventory = false,
@@ -1198,23 +1296,23 @@ async function uploadCollectionData(
   }
 
   const result = await authenticatedPost(`/collection/${endpoint}/import`, body)
-  if (result.error) return result
+  if (result.error) return { error: result.error }
 
   collectionIdsCache = null
 
   return {
-    success: result.data!.success,
-    created: result.data!.created ?? 0,
-    updated: result.data!.updated ?? 0,
-    skipped: result.data!.skipped ?? 0,
-    errors: result.data!.errors ?? [],
+    success: result.data!.success as boolean,
+    created: (result.data!.created as number) ?? 0,
+    updated: (result.data!.updated as number) ?? 0,
+    skipped: (result.data!.skipped as number) ?? 0,
+    errors: (result.data!.errors as unknown[]) ?? [],
     reconciliation: result.data!.reconciliation ?? null
   }
 }
 
 async function uploadCharacterStats(
   statsData: Record<string, CharacterStatsEntry>
-): Promise<Record<string, unknown>> {
+): Promise<UploadCollectionResult> {
   const items = Object.values(statsData).map((char) => {
     const item: Record<string, unknown> = { granblue_id: char.masterId }
 
@@ -1263,20 +1361,20 @@ async function uploadCharacterStats(
     data: { list: items },
     update_existing: true
   })
-  if (result.error) return result
+  if (result.error) return { error: result.error }
 
   collectionIdsCache = null
 
   return {
-    success: result.data!.success,
-    created: result.data!.created ?? 0,
-    updated: result.data!.updated ?? 0,
-    skipped: result.data!.skipped ?? 0,
-    errors: result.data!.errors ?? []
+    success: result.data!.success as boolean,
+    created: (result.data!.created as number) ?? 0,
+    updated: (result.data!.updated as number) ?? 0,
+    skipped: (result.data!.skipped as number) ?? 0,
+    errors: (result.data!.errors as unknown[]) ?? []
   }
 }
 
-async function fetchUserPlaylists(): Promise<Record<string, unknown>> {
+async function fetchUserPlaylists(): Promise<FetchPlaylistsResult> {
   try {
     const auth = await getAuthToken()
     if (!auth) return { error: 'not_logged_in' }
@@ -1304,7 +1402,7 @@ async function createPlaylist({
   title: string
   description: string
   visibility: number
-}): Promise<Record<string, unknown>> {
+}): Promise<CreatePlaylistResult> {
   try {
     const result = await authenticatedPost('/playlists', {
       playlist: { title, description, visibility: visibility || 3 }
@@ -1318,7 +1416,7 @@ async function createPlaylist({
 
 async function fetchRaidGroups(
   forceRefresh = false
-): Promise<Record<string, unknown>> {
+): Promise<FetchRaidGroupsResult> {
   const cacheKey = CACHE_KEYS.raid_groups!
   const result = await chrome.storage.local.get(cacheKey)
   const cached = result[cacheKey] as
@@ -1361,7 +1459,7 @@ async function fetchRaidGroups(
   }
 }
 
-async function getCollectionIds(): Promise<unknown> {
+async function getCollectionIds(): Promise<{ error?: string; weapons?: string[]; summons?: string[]; characters?: string[]; artifacts?: string[] }> {
   const now = Date.now()
   if (
     collectionIdsCache &&

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -60,8 +60,8 @@ export function formatCacheStatus(
         type.startsWith('stash_')
       ) {
         subtitle = t('count_items_pages', {
-          items: info.totalItems,
-          pages: info.pageCount
+          items: info.totalItems ?? 0,
+          pages: info.pageCount ?? 0
         })
       }
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -3,19 +3,19 @@
  * Provides helper functions for formatting cache status and managing cache data.
  */
 
+import * as m from '../paraglide/messages.js'
 import { CACHE_TTL_MS, getDataTypeName } from './constants.js'
-import { t } from './i18n.js'
 import type { CacheStatusInfo, FormattedCacheStatus } from './types/cache.js'
 
 export function formatAge(ageMs: number): string {
   const seconds = Math.floor(ageMs / 1000)
-  if (seconds < 60) return t('time_seconds_ago', { count: seconds })
+  if (seconds < 60) return m.time_seconds_ago({ count: seconds })
 
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return t('time_minutes_ago', { count: minutes })
+  if (minutes < 60) return m.time_minutes_ago({ count: minutes })
 
   const hours = Math.floor(minutes / 60)
-  return t('time_hours_ago', { count: hours })
+  return m.time_hours_ago({ count: hours })
 }
 
 export function isStale(timestamp: number): boolean {
@@ -38,7 +38,7 @@ export function formatCacheStatus(
         ...info,
         displayName: stashDisplayName,
         subtitle: null,
-        ageText: t('cache_no_data'),
+        ageText: m.cache_no_data(),
         statusClass: 'unavailable'
       }
     } else if (info.isStale) {
@@ -46,7 +46,7 @@ export function formatCacheStatus(
         ...info,
         displayName: stashDisplayName,
         subtitle: null,
-        ageText: t('cache_stale'),
+        ageText: m.cache_stale(),
         statusClass: 'stale'
       }
     } else {
@@ -59,18 +59,18 @@ export function formatCacheStatus(
         type.startsWith('collection_') ||
         type.startsWith('stash_')
       ) {
-        subtitle = t('count_items_pages', {
+        subtitle = m.count_items_pages({
           items: info.totalItems ?? 0,
           pages: info.pageCount ?? 0
         })
       }
 
       if (type.startsWith('detail_npc_')) {
-        displayName = info.itemName ?? t('type_character')
+        displayName = info.itemName ?? m.type_character()
       } else if (type.startsWith('detail_weapon_')) {
-        displayName = info.itemName ?? t('type_weapon')
+        displayName = info.itemName ?? m.type_weapon()
       } else if (type.startsWith('detail_summon_')) {
-        displayName = info.itemName ?? t('type_summon')
+        displayName = info.itemName ?? m.type_summon()
       }
 
       formatted[type] = {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,8 +3,8 @@
  * Centralizes all configuration values, URLs, and data type definitions.
  */
 
+import * as m from '../paraglide/messages.js'
 import { safeGet } from './storage.js'
-import { t } from './i18n.js'
 
 // ==========================================
 // API CONFIGURATION
@@ -120,29 +120,29 @@ export const RAID_SECTIONS = {
 // DATA TYPE DEFINITIONS
 // ==========================================
 
-const DATA_TYPE_I18N_KEYS: Record<string, string> = {
-  party: 'type_party',
-  detail_npc: 'type_character',
-  detail_weapon: 'type_weapon',
-  detail_summon: 'type_summon',
-  list_npc: 'type_character_list',
-  list_weapon: 'type_weapon_list',
-  list_summon: 'type_summon_list',
-  collection_weapon: 'type_weapon_collection',
-  collection_npc: 'type_character_collection',
-  collection_summon: 'type_summon_collection',
-  collection_artifact: 'type_artifact_collection',
-  character_stats: 'type_character_stats'
+const DATA_TYPE_NAMES: Record<string, () => string> = {
+  party: m.type_party,
+  detail_npc: m.type_character,
+  detail_weapon: m.type_weapon,
+  detail_summon: m.type_summon,
+  list_npc: m.type_character_list,
+  list_weapon: m.type_weapon_list,
+  list_summon: m.type_summon_list,
+  collection_weapon: m.type_weapon_collection,
+  collection_npc: m.type_character_collection,
+  collection_summon: m.type_summon_collection,
+  collection_artifact: m.type_artifact_collection,
+  character_stats: m.type_character_stats
 }
 
 export function getDataTypeName(dataType: string): string {
-  const key = DATA_TYPE_I18N_KEYS[dataType]
-  if (key) return t(key)
+  const fn = DATA_TYPE_NAMES[dataType]
+  if (fn) return fn()
   if (dataType.startsWith('stash_weapon_')) {
-    return t('type_weapon_stash')
+    return m.type_weapon_stash()
   }
   if (dataType.startsWith('stash_summon_')) {
-    return t('type_summon_stash')
+    return m.type_summon_stash()
   }
   return dataType
 }

--- a/src/lib/debugger.ts
+++ b/src/lib/debugger.ts
@@ -122,7 +122,7 @@ async function attachToExistingTabs(): Promise<void> {
 
 function handleTabUpdated(
   tabId: number,
-  changeInfo: chrome.tabs.TabChangeInfo,
+  changeInfo: chrome.tabs.OnUpdatedInfo,
   tab: chrome.tabs.Tab
 ): void {
   if (

--- a/src/lib/detail-helpers.ts
+++ b/src/lib/detail-helpers.ts
@@ -15,7 +15,8 @@ import {
   AUGMENT_ICON_MAP,
   resolveForgedSummonId
 } from './game-data.js'
-import { t, tPlural, translateSeries, getLocale } from './i18n.js'
+import * as m from '../paraglide/messages.js'
+import { translateSeries, getLocale } from './i18n.js'
 
 // ==========================================
 // RAW API ITEM SHAPES
@@ -420,7 +421,7 @@ export function buildAxTooltip(
 ): string {
   const iconSlug = iconImage || 'ex_skill_atk'
   const axEntries = Object.values(skill || {})
-  if (axEntries.length === 0) return t('stat_ax_skills')
+  if (axEntries.length === 0) return m.stat_ax_skills()
   return axEntries
     .map((s: RawAugmentSkillEntry) => {
       const entryIconSlug = s.image || iconSlug
@@ -512,13 +513,13 @@ function renderBaseStats({
   const level = param.level || master.max_level
 
   let html = '<div class="database-stats">'
-  html += statRow(t('stat_name'), name)
-  if (id) html += statRow(t('stat_id'), id)
+  html += statRow(m.stat_name(), name)
+  if (id) html += statRow(m.stat_id(), id)
 
   const seriesId = Number(data.series_id || master.series_id)
   if (seriesId && seriesMap?.[seriesId]) {
     html += statRow(
-      t('stat_series'),
+      m.stat_series(),
       translateSeries(seriesMap[seriesId]!, type)
     )
   }
@@ -528,7 +529,7 @@ function renderBaseStats({
     GAME_ELEMENT_NAMES[element as keyof typeof GAME_ELEMENT_NAMES]
   ) {
     html += statRow(
-      t('stat_element'),
+      m.stat_element(),
       `<img class="stat-icon" src="${getImageUrl(`labels/element/Label_Element_${GAME_ELEMENT_NAMES[element as keyof typeof GAME_ELEMENT_NAMES]}.png`)}" alt="${GAME_ELEMENT_NAMES[element as keyof typeof GAME_ELEMENT_NAMES]}">`
     )
   }
@@ -541,17 +542,17 @@ function renderBaseStats({
           `<img class="stat-icon" src="${getImageUrl(`labels/proficiency/Label_Weapon_${GAME_PROFICIENCY_NAMES[p as number]}.png`)}" alt="${GAME_PROFICIENCY_NAMES[p as number]}">`
       )
       .join('')
-    if (profIcons) html += statRow(t('stat_proficiency'), profIcons)
+    if (profIcons) html += statRow(m.stat_proficiency(), profIcons)
   }
 
-  if (level) html += statRow(t('stat_uncap'), renderStars(Number(level), type))
-  if (minHp) html += statRow(t('stat_min_hp'), Number(minHp).toLocaleString())
-  if (maxHp) html += statRow(t('stat_max_hp'), Number(maxHp).toLocaleString())
+  if (level) html += statRow(m.stat_uncap(), renderStars(Number(level), type))
+  if (minHp) html += statRow(m.stat_min_hp(), Number(minHp).toLocaleString())
+  if (maxHp) html += statRow(m.stat_max_hp(), Number(maxHp).toLocaleString())
   if (minAtk)
-    html += statRow(t('stat_min_atk'), Number(minAtk).toLocaleString())
+    html += statRow(m.stat_min_atk(), Number(minAtk).toLocaleString())
   if (maxAtk)
-    html += statRow(t('stat_max_atk'), Number(maxAtk).toLocaleString())
-  if (level) html += statRow(t('stat_max_level'), String(level))
+    html += statRow(m.stat_max_atk(), Number(maxAtk).toLocaleString())
+  if (level) html += statRow(m.stat_max_level(), String(level))
 
   return { html, master, param }
 }
@@ -591,7 +592,7 @@ export function renderCharacterStats(
   let html = base
 
   if (param.has_npcaugment_constant) {
-    html += statRow(t('stat_perpetuity_ring'), '\u2713')
+    html += statRow(m.stat_perpetuity_ring(), '\u2713')
   }
 
   return closeStats(html, data, master)
@@ -622,7 +623,7 @@ export function renderWeaponStats(
   const arousal = param.arousal
   if (arousal?.is_arousal_weapon) {
     html += statRow(
-      t('stat_awakening'),
+      m.stat_awakening(),
       `${arousal.form_name || 'Attack'} Lv.${arousal.level || 1}`
     )
   }
@@ -633,9 +634,9 @@ export function renderWeaponStats(
     const befoulSkill = befoulSkillMap
       ? Object.values(befoulSkillMap)[0]
       : undefined
-    html += statRow(t('stat_befoulment'), befoulSkill?.show_value || 'Active')
+    html += statRow(m.stat_befoulment(), befoulSkill?.show_value || 'Active')
     html += statRow(
-      t('stat_exorcism'),
+      m.stat_exorcism(),
       `${odiant.exorcision_level || 0}/${odiant.max_exorcision_level || 5}`
     )
   } else {
@@ -643,7 +644,7 @@ export function renderWeaponStats(
     if (axSkills && Object.keys(axSkills).length > 0) {
       const axCount = Object.keys(axSkills).length
       html += statRow(
-        t('stat_ax_skills'),
+        m.stat_ax_skills(),
         `${axCount} skill${axCount > 1 ? 's' : ''}`
       )
     }
@@ -670,7 +671,7 @@ export function renderSummonStats(
 
   const subAura = data.sub_skill?.name
   if (subAura) {
-    html += statRow(t('stat_sub_aura'), subAura)
+    html += statRow(m.stat_sub_aura(), subAura)
   }
 
   return closeStats(html, data, master)

--- a/src/lib/detail-helpers.ts
+++ b/src/lib/detail-helpers.ts
@@ -18,6 +18,118 @@ import {
 import { t, tPlural, translateSeries, getLocale } from './i18n.js'
 
 // ==========================================
+// RAW API ITEM SHAPES
+// ==========================================
+
+/** Fields accessed on master sub-objects across item types */
+interface RawMaster {
+  id?: string
+  name?: string
+  series_id?: string | number
+  kind?: string | number
+  attribute?: string | number
+  rarity?: string | number
+  element?: string | number
+  specialty_weapon?: Array<string | number>
+  comment?: string
+  default_hp?: string | number
+  default_attack?: string | number
+  max_hp?: string | number
+  max_attack?: string | number
+  max_level?: string | number
+}
+
+/** AX / befoulment skill entry as returned by the API */
+interface RawAugmentSkillEntry {
+  image?: string
+  show_value?: string
+  [key: string]: unknown
+}
+
+/** Awakening (arousal) data nested in param */
+interface RawArousal {
+  form_id?: number
+  form_name?: string
+  level?: number
+  is_arousal_weapon?: boolean
+}
+
+/** Befoulment (odiant) data nested in param */
+interface RawOdiant {
+  is_odiant_weapon?: boolean
+  exorcision_level?: number
+  max_exorcision_level?: number
+}
+
+/** Fields accessed on param sub-objects across item types */
+interface RawParam {
+  id?: string
+  evolution?: number
+  phase?: number
+  style?: string
+  image_id?: string
+  level?: string | number
+  hp?: string | number
+  attack?: string | number
+  has_npcaugment_constant?: boolean
+  arousal?: RawArousal
+  odiant?: RawOdiant
+  augment_skill_info?: Array<Record<string, RawAugmentSkillEntry>>
+  augment_skill_icon_image?: string[]
+}
+
+/** Weapon skill reference on top-level item */
+interface RawWeaponSkillRef {
+  id?: string
+  [key: string]: unknown
+}
+
+/** A raw game item as received from the API, covering characters, weapons, summons */
+export interface RawGameItem {
+  id?: string
+  master?: RawMaster
+  param?: RawParam
+  skill1?: RawWeaponSkillRef
+  skill2?: RawWeaponSkillRef
+  skill3?: RawWeaponSkillRef
+  artifact_id?: string
+  attribute?: string | number
+  element?: string | number
+  kind?: string | number
+  weapon_kind?: string | number
+  series_id?: string | number
+  default_hp?: string | number
+  default_attack?: string | number
+  max_hp?: string | number
+  max_attack?: string | number
+  max_attack_2?: string | number
+  comment?: string
+  sub_skill?: { name?: string }
+  [key: string]: unknown
+}
+
+/** Page shape within collection/list/stash responses */
+interface CollectionPage {
+  list?: RawGameItem[]
+  [key: string]: unknown
+}
+
+/** Party data shape */
+interface PartyData {
+  deck?: {
+    pc?: {
+      weapons?: Record<string, RawGameItem | null> | RawGameItem[]
+      summons?: Record<string, RawGameItem | null> | RawGameItem[]
+      sub_summons?: Record<string, RawGameItem | null> | RawGameItem[]
+      [key: string]: unknown
+    }
+    npc?: Record<string, RawGameItem | null> | RawGameItem[]
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+// ==========================================
 // DATA TYPE HELPERS
 // ==========================================
 
@@ -49,35 +161,44 @@ export function isWeaponOrSummonCollection(dataType: string): boolean {
 // DATA EXTRACTION
 // ==========================================
 
-export function toArray(data: any): any[] {
+export function toArray(data: unknown): unknown[] {
   if (!data) return []
   if (Array.isArray(data)) return data
-  return Object.values(data)
+  if (typeof data === 'object')
+    return Object.values(data as Record<string, unknown>)
+  return []
 }
 
-export function extractItems(dataType: string, data: any): any[] {
+export function extractItems(
+  dataType: string,
+  data: Record<string, CollectionPage> | PartyData | RawGameItem
+): RawGameItem[] {
   if (
     dataType.startsWith('collection_') ||
     dataType.startsWith('list_') ||
     dataType.startsWith('stash_')
   ) {
-    const pages = Object.values(data) as any[]
+    const pages = Object.values(data as Record<string, CollectionPage>)
     return pages.flatMap((page) => page.list || [])
   }
   if (dataType.startsWith('party_')) {
-    const deck = data.deck || {}
+    const partyData = data as PartyData
+    const deck = partyData.deck || {}
     const pc = deck.pc || {}
     return [
       ...toArray(deck.npc),
       ...toArray(pc.weapons),
       ...toArray(pc.summons),
       ...toArray(pc.sub_summons)
-    ].filter(Boolean)
+    ].filter(Boolean) as RawGameItem[]
   }
-  return [data]
+  return [data as RawGameItem]
 }
 
-export function countItems(dataType: string, data: any): number {
+export function countItems(
+  dataType: string,
+  data: Record<string, CollectionPage> | PartyData | RawGameItem
+): number {
   return extractItems(dataType, data).length
 }
 
@@ -96,14 +217,17 @@ function getCharacterPose(
   return '_01'
 }
 
-function getCharacterImageSuffix(item: any, simplePortraits: boolean): string {
+function getCharacterImageSuffix(
+  item: RawGameItem,
+  simplePortraits: boolean
+): string {
   if (item.param?.style === '2') return '_01_style'
   const evolution = item.param?.evolution
   const phase = item.param?.phase
   return getCharacterPose(evolution, phase, simplePortraits)
 }
 
-function getImageSuffix(item: any): string {
+function getImageSuffix(item: RawGameItem): string {
   const imageId = item.param?.image_id
   if (!imageId) return ''
 
@@ -115,7 +239,7 @@ function getImageSuffix(item: any): string {
 
 export function getItemImageUrl(
   dataType: string,
-  item: any,
+  item: RawGameItem,
   simplePortraits: boolean
 ): string {
   const granblueId = item.master?.id || item.param?.id || item.id
@@ -130,7 +254,7 @@ export function getItemImageUrl(
   }
   if (dataType.includes('summon')) {
     const suffix = getImageSuffix(item)
-    const resolvedId = resolveForgedSummonId(granblueId)
+    const resolvedId = resolveForgedSummonId(granblueId ?? '')
     return getImageUrl(`summon-square/${resolvedId}${suffix}.jpg`)
   }
   if (dataType.includes('artifact')) {
@@ -140,7 +264,7 @@ export function getItemImageUrl(
   return ''
 }
 
-export function getArtifactLabels(item: any): string {
+export function getArtifactLabels(item: RawGameItem): string {
   const element = item.attribute || item.element
   const proficiency = item.kind || item.weapon_kind
 
@@ -153,8 +277,8 @@ export function getArtifactLabels(item: any): string {
     html += `<img class="label-icon" src="${getImageUrl(`labels/element/Label_Element_${GAME_ELEMENT_NAMES[element as keyof typeof GAME_ELEMENT_NAMES]}.png`)}" alt="">`
   }
 
-  if (proficiency && GAME_PROFICIENCY_NAMES[proficiency]) {
-    html += `<img class="label-icon" src="${getImageUrl(`labels/proficiency/Label_Weapon_${GAME_PROFICIENCY_NAMES[proficiency]}.png`)}" alt="">`
+  if (proficiency && GAME_PROFICIENCY_NAMES[Number(proficiency)]) {
+    html += `<img class="label-icon" src="${getImageUrl(`labels/proficiency/Label_Weapon_${GAME_PROFICIENCY_NAMES[Number(proficiency)]}.png`)}" alt="">`
   }
 
   html += '</div>'
@@ -178,7 +302,7 @@ export interface CharacterModifiers {
   perpetuity: boolean
 }
 
-export function getCharacterModifiers(item: any): CharacterModifiers {
+export function getCharacterModifiers(item: RawGameItem): CharacterModifiers {
   const param = item.param || {}
   return {
     perpetuity: !!param.has_npcaugment_constant
@@ -191,9 +315,12 @@ export interface WeaponModifiers {
     level: number
     is_arousal_weapon: boolean
   } | null
-  axSkill: { skill: any; iconImage: string | null } | null
+  axSkill: {
+    skill: Record<string, RawAugmentSkillEntry>
+    iconImage: string | null
+  } | null
   befoulment: {
-    skill: any
+    skill: Record<string, RawAugmentSkillEntry> | null
     exorcismLevel: number
     maxExorcismLevel: number
     iconImage: string | null
@@ -202,20 +329,21 @@ export interface WeaponModifiers {
 }
 
 export function getWeaponModifiers(
-  item: any,
+  item: RawGameItem,
   weaponKeyMap: Record<string, string> | null = null
 ): WeaponModifiers {
-  const param = item.param || {}
-  const odiant = param.odiant || {}
+  const param = item.param ?? ({} as RawParam)
+  const odiant = param.odiant ?? ({} as RawOdiant)
   const isOdiant = odiant.is_odiant_weapon === true
 
   const weaponKeys: string[] = []
   if (weaponKeyMap) {
-    const seriesId = parseInt(item.master?.series_id)
+    const seriesId = parseInt(String(item.master?.series_id))
     if (WEAPON_KEY_SERIES.has(seriesId)) {
-      const weaponProficiency = parseInt(item.master?.kind) || null
-      for (const skillKey of ['skill1', 'skill2', 'skill3']) {
-        const skillId = item[skillKey]?.id
+      const weaponProficiency = parseInt(String(item.master?.kind)) || null
+      for (const skillKey of ['skill1', 'skill2', 'skill3'] as const) {
+        const skillRef = item[skillKey] as RawWeaponSkillRef | undefined
+        const skillId = skillRef?.id
         if (skillId && weaponKeyMap[skillId]) {
           const slug = weaponKeyMap[skillId]
           const GAUPH_SLOT0 = [
@@ -238,18 +366,25 @@ export function getWeaponModifiers(
       param.arousal?.is_arousal_weapon &&
       param.arousal?.form_name &&
       param.arousal?.level
-        ? param.arousal
+        ? {
+            form_name: param.arousal.form_name,
+            level: param.arousal.level,
+            is_arousal_weapon: param.arousal.is_arousal_weapon!
+          }
         : null,
     axSkill:
       !isOdiant && param.augment_skill_info?.[0]
         ? {
-            skill: param.augment_skill_info[0],
+            skill: param.augment_skill_info[0]!,
             iconImage: param.augment_skill_icon_image?.[0] || null
           }
         : null,
     befoulment: isOdiant
       ? {
-          skill: param.augment_skill_info?.[0]?.[0] || null,
+          skill:
+            (param.augment_skill_info?.[0] as
+              | Record<string, RawAugmentSkillEntry>
+              | undefined) ?? null,
           exorcismLevel: odiant.exorcision_level || 0,
           maxExorcismLevel: odiant.max_exorcision_level || 5,
           iconImage: param.augment_skill_icon_image?.[0] || null
@@ -269,18 +404,25 @@ export function resolveAwakeningIcon(formName: string): string {
   return WEAPON_AWAKENING_ICONS[formName] || 'weapon-atk'
 }
 
+/** Modifier name entry used for AX skill tooltip lookup */
+interface WeaponStatModifier {
+  nameEn?: string
+  nameJp?: string
+  [key: string]: unknown
+}
+
 /** Build an AX skill tooltip from skill entries */
 export function buildAxTooltip(
-  skill: any,
+  skill: Record<string, RawAugmentSkillEntry> | null,
   iconImage: string | null,
-  weaponStatModifiers: Record<string, any> | null,
+  weaponStatModifiers: Record<string, WeaponStatModifier> | null,
   locale: string
 ): string {
   const iconSlug = iconImage || 'ex_skill_atk'
   const axEntries = Object.values(skill || {})
   if (axEntries.length === 0) return t('stat_ax_skills')
   return axEntries
-    .map((s: any) => {
+    .map((s: RawAugmentSkillEntry) => {
       const entryIconSlug = s.image || iconSlug
       const entryFile = AUGMENT_ICON_MAP[entryIconSlug] || entryIconSlug
       const mod = weaponStatModifiers?.[entryFile]
@@ -352,7 +494,7 @@ function renderBaseStats({
   proficiencies,
   type
 }: {
-  data: any
+  data: RawGameItem
   name: string
   id: string
   seriesMap?: Record<number, string>
@@ -360,8 +502,8 @@ function renderBaseStats({
   proficiencies?: Array<string | number>
   type: 'weapon' | 'summon' | 'character'
 }) {
-  const master = data.master || data
-  const param = data.param || {}
+  const master = data.master ?? data
+  const param = data.param ?? ({} as RawParam)
 
   const minHp = master.default_hp || data.default_hp
   const maxHp = param.hp || master.max_hp || data.max_hp
@@ -373,11 +515,11 @@ function renderBaseStats({
   html += statRow(t('stat_name'), name)
   if (id) html += statRow(t('stat_id'), id)
 
-  const seriesId = data.series_id || master.series_id
+  const seriesId = Number(data.series_id || master.series_id)
   if (seriesId && seriesMap?.[seriesId]) {
     html += statRow(
       t('stat_series'),
-      translateSeries(seriesMap[seriesId], type)
+      translateSeries(seriesMap[seriesId]!, type)
     )
   }
 
@@ -402,19 +544,23 @@ function renderBaseStats({
     if (profIcons) html += statRow(t('stat_proficiency'), profIcons)
   }
 
-  if (level) html += statRow(t('stat_uncap'), renderStars(level, type))
+  if (level) html += statRow(t('stat_uncap'), renderStars(Number(level), type))
   if (minHp) html += statRow(t('stat_min_hp'), Number(minHp).toLocaleString())
   if (maxHp) html += statRow(t('stat_max_hp'), Number(maxHp).toLocaleString())
   if (minAtk)
     html += statRow(t('stat_min_atk'), Number(minAtk).toLocaleString())
   if (maxAtk)
     html += statRow(t('stat_max_atk'), Number(maxAtk).toLocaleString())
-  if (level) html += statRow(t('stat_max_level'), level)
+  if (level) html += statRow(t('stat_max_level'), String(level))
 
   return { html, master, param }
 }
 
-function closeStats(html: string, data: any, master: any): string {
+function closeStats(
+  html: string,
+  data: RawGameItem,
+  master: RawMaster | RawGameItem
+): string {
   const comment = data.comment || master.comment
   if (comment) {
     html += `<div class="stat-row stat-comment"><span class="stat-value">${comment}</span></div>`
@@ -423,7 +569,7 @@ function closeStats(html: string, data: any, master: any): string {
 }
 
 export function renderCharacterStats(
-  data: any,
+  data: RawGameItem,
   name: string,
   id: string,
   element: string | number | undefined,
@@ -452,7 +598,7 @@ export function renderCharacterStats(
 }
 
 export function renderWeaponStats(
-  data: any,
+  data: RawGameItem,
   name: string,
   id: string,
   element: string | number | undefined,
@@ -483,7 +629,10 @@ export function renderWeaponStats(
 
   const odiant = param.odiant
   if (odiant?.is_odiant_weapon) {
-    const befoulSkill = param.augment_skill_info?.[0]?.[0]
+    const befoulSkillMap = param.augment_skill_info?.[0]
+    const befoulSkill = befoulSkillMap
+      ? Object.values(befoulSkillMap)[0]
+      : undefined
     html += statRow(t('stat_befoulment'), befoulSkill?.show_value || 'Active')
     html += statRow(
       t('stat_exorcism'),
@@ -504,7 +653,7 @@ export function renderWeaponStats(
 }
 
 export function renderSummonStats(
-  data: any,
+  data: RawGameItem,
   name: string,
   id: string,
   element: string | number | undefined

--- a/src/lib/detail-helpers.ts
+++ b/src/lib/detail-helpers.ts
@@ -548,10 +548,8 @@ function renderBaseStats({
   if (level) html += statRow(m.stat_uncap(), renderStars(Number(level), type))
   if (minHp) html += statRow(m.stat_min_hp(), Number(minHp).toLocaleString())
   if (maxHp) html += statRow(m.stat_max_hp(), Number(maxHp).toLocaleString())
-  if (minAtk)
-    html += statRow(m.stat_min_atk(), Number(minAtk).toLocaleString())
-  if (maxAtk)
-    html += statRow(m.stat_max_atk(), Number(maxAtk).toLocaleString())
+  if (minAtk) html += statRow(m.stat_min_atk(), Number(minAtk).toLocaleString())
+  if (maxAtk) html += statRow(m.stat_max_atk(), Number(maxAtk).toLocaleString())
   if (level) html += statRow(m.stat_max_level(), String(level))
 
   return { html, master, param }

--- a/src/lib/detail-helpers.ts
+++ b/src/lib/detail-helpers.ts
@@ -405,7 +405,7 @@ export function resolveAwakeningIcon(formName: string): string {
 }
 
 /** Modifier name entry used for AX skill tooltip lookup */
-interface WeaponStatModifier {
+export interface WeaponStatModifier {
   nameEn?: string
   nameJp?: string
   [key: string]: unknown

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -42,6 +42,26 @@ export function getPreferredLocale(gbAuth: AuthWithLanguage | null): Locale {
 }
 
 // ==========================================
+// ERROR CODE TRANSLATION
+// ==========================================
+
+const ERROR_MESSAGES: Record<string, () => string> = {
+  not_logged_in: m.error_not_logged_in,
+  no_cached_data: m.error_no_cached_data,
+  stale_data: m.error_stale_data,
+  no_character_stats: m.error_no_character_stats,
+  no_items: m.error_no_items,
+  unknown_type: m.error_unknown_type,
+  request_failed: m.error_request_failed,
+  server_error: m.error_server_error
+}
+
+export function translateError(code: string): string {
+  const fn = ERROR_MESSAGES[code]
+  return fn ? fn() : m.error_request_failed()
+}
+
+// ==========================================
 // SERIES NAME TRANSLATION
 // ==========================================
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -18,13 +18,12 @@ export type Locale = 'en' | 'ja'
 
 // Build a lookup from string keys to Paraglide message functions.
 // This allows the existing t(key) API to delegate to Paraglide.
-type MessageFn = ((params?: Record<string, unknown>) => string) &
-  Record<string, unknown>
+type MessageFn = (params?: Record<string, unknown>) => string
 
 const registry: Record<string, MessageFn> = {}
 for (const [key, fn] of Object.entries(m)) {
   if (typeof fn === 'function' && key !== 'm') {
-    registry[key] = fn as MessageFn
+    registry[key] = fn as unknown as MessageFn
   }
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,6 +1,7 @@
 /**
  * Internationalization module for the Chrome extension.
- * Wraps Paraglide message functions to maintain backward-compatible API.
+ * Thin wrapper around Paraglide runtime for locale management
+ * and series/element/proficiency name translation.
  */
 
 import * as m from '../paraglide/messages.js'
@@ -13,111 +14,7 @@ import {
 export type Locale = 'en' | 'ja'
 
 // ==========================================
-// MESSAGE REGISTRY
-// ==========================================
-
-// Build a lookup from string keys to Paraglide message functions.
-// This allows the existing t(key) API to delegate to Paraglide.
-type MessageFn = (params?: Record<string, unknown>) => string
-
-const registry: Record<string, MessageFn> = {}
-for (const [key, fn] of Object.entries(m)) {
-  if (typeof fn === 'function' && key !== 'm') {
-    registry[key] = fn as unknown as MessageFn
-  }
-}
-
-// ==========================================
-// SERIES NAME LOOKUP MAPS
-// ==========================================
-
-const WEAPON_SERIES_I18N: Record<string, string> = {
-  Seraphic: 'series_seraphic',
-  Grand: 'series_grand',
-  'Dark Opus': 'series_dark_opus',
-  Revenant: 'series_revenant',
-  Primal: 'series_primal',
-  Beast: 'series_beast',
-  Regalia: 'series_regalia',
-  Omega: 'series_omega',
-  'Olden Primal': 'series_olden_primal',
-  Hollowsky: 'series_hollowsky',
-  Xeno: 'series_xeno',
-  Rose: 'series_rose',
-  Ultima: 'series_ultima',
-  Bahamut: 'series_bahamut',
-  Epic: 'series_epic',
-  Cosmos: 'series_cosmos',
-  Superlative: 'series_superlative',
-  Vintage: 'series_vintage',
-  'Class Champion': 'series_class_champion',
-  Replica: 'series_replica',
-  Relic: 'series_relic',
-  Rusted: 'series_rusted',
-  Sephira: 'series_sephira',
-  Vyrmament: 'series_vyrmament',
-  Upgrader: 'series_upgrader',
-  Astral: 'series_astral',
-  Draconic: 'series_draconic',
-  'Eternal Splendor': 'series_eternal_splendor',
-  Ancestral: 'series_ancestral',
-  'New World Foundation': 'series_new_world',
-  Ennead: 'series_ennead',
-  Militis: 'series_militis',
-  Malice: 'series_malice',
-  Menace: 'series_menace',
-  Illustrious: 'series_illustrious',
-  Proven: 'series_proven',
-  Revans: 'series_revans',
-  World: 'series_world',
-  Exo: 'series_exo',
-  'Draconic Providence': 'series_draconic_providence',
-  Celestial: 'series_celestial',
-  'Omega Rebirth': 'series_omega_rebirth',
-  Collab: 'series_collab',
-  Destroyer: 'series_destroyer'
-}
-
-const SUMMON_SERIES_I18N: Record<string, string> = {
-  Providence: 'series_providence',
-  Genesis: 'series_genesis',
-  Magna: 'series_magna',
-  Optimus: 'series_optimus',
-  'Demi Optimus': 'series_demi_optimus',
-  Archangel: 'series_archangel',
-  Arcarum: 'series_arcarum',
-  Epic: 'series_epic',
-  Carbuncle: 'series_carbuncle',
-  Dynamis: 'series_dynamis',
-  Cryptid: 'series_cryptid',
-  'Six Dragons': 'series_six_dragons',
-  Summer: 'series_summer',
-  Yukata: 'series_yukata',
-  Holiday: 'series_holiday',
-  Collab: 'series_collab',
-  Bellum: 'series_bellum',
-  Crest: 'series_crest',
-  Robur: 'series_robur'
-}
-
-const CHARACTER_SERIES_I18N: Record<string, string> = {
-  Summer: 'series_summer',
-  Yukata: 'series_yukata',
-  Valentine: 'series_valentine',
-  Halloween: 'series_halloween',
-  Holiday: 'series_holiday',
-  Zodiac: 'series_zodiac',
-  Grand: 'series_grand',
-  Fantasy: 'series_fantasy',
-  Collab: 'series_collab',
-  Eternal: 'series_eternal',
-  Evoker: 'series_evoker',
-  Saint: 'series_saint',
-  Formal: 'series_formal'
-}
-
-// ==========================================
-// PUBLIC API
+// LOCALE MANAGEMENT
 // ==========================================
 
 export function setLocale(lang: string): void {
@@ -127,91 +24,6 @@ export function setLocale(lang: string): void {
 
 export function getLocale(): Locale {
   return paraglideGetLocale() as Locale
-}
-
-export function t(
-  key: string,
-  params?: Record<string, string | number>
-): string {
-  const fn = registry[key]
-  if (!fn) return key
-  return fn(params)
-}
-
-export function tPlural(
-  singular: string,
-  plural: string,
-  count: number,
-  params: Record<string, string | number> = {}
-): string {
-  const key = count === 1 ? singular : plural
-  return t(key, { count, ...params })
-}
-
-export function tError(code: string): string {
-  const key = `error_${code}`
-  return registry[key] ? t(key) : t('error_request_failed')
-}
-
-export function translateSeries(
-  englishName: string,
-  type: 'weapon' | 'summon' | 'character'
-): string {
-  if (getLocale() === 'en') return englishName
-
-  let map: Record<string, string>
-  if (type === 'weapon') map = WEAPON_SERIES_I18N
-  else if (type === 'summon') map = SUMMON_SERIES_I18N
-  else if (type === 'character') map = CHARACTER_SERIES_I18N
-  else return englishName
-
-  const key = map[englishName]
-  if (!key) return englishName
-
-  return registry[key] ? t(key) : englishName
-}
-
-export function translateElement(englishName: string): string {
-  if (getLocale() === 'en') return englishName
-  const key = `element_${englishName.toLowerCase()}`
-  return registry[key] ? t(key) : englishName
-}
-
-export function translateProficiency(englishName: string): string {
-  if (getLocale() === 'en') return englishName
-  const key = `proficiency_${englishName.toLowerCase()}`
-  return registry[key] ? t(key) : englishName
-}
-
-export function translatePage(): void {
-  document.querySelectorAll<HTMLElement>('[data-i18n]').forEach((el) => {
-    const key = el.dataset.i18n
-    if (!key) return
-    const translated = t(key)
-    if (translated !== key) {
-      el.textContent = translated
-    }
-  })
-
-  document
-    .querySelectorAll<HTMLInputElement>('[data-i18n-placeholder]')
-    .forEach((el) => {
-      const key = el.dataset.i18nPlaceholder
-      if (!key) return
-      const translated = t(key)
-      if (translated !== key) {
-        el.placeholder = translated
-      }
-    })
-
-  document.querySelectorAll<HTMLElement>('[data-i18n-title]').forEach((el) => {
-    const key = el.dataset.i18nTitle
-    if (!key) return
-    const translated = t(key)
-    if (translated !== key) {
-      el.title = translated
-    }
-  })
 }
 
 interface AuthWithLanguage {
@@ -227,4 +39,143 @@ export function getPreferredLocale(gbAuth: AuthWithLanguage | null): Locale {
   } catch {
     return 'en'
   }
+}
+
+// ==========================================
+// SERIES NAME TRANSLATION
+// ==========================================
+
+const WEAPON_SERIES: Record<string, () => string> = {
+  Seraphic: m.series_seraphic,
+  Grand: m.series_grand,
+  'Dark Opus': m.series_dark_opus,
+  Revenant: m.series_revenant,
+  Primal: m.series_primal,
+  Beast: m.series_beast,
+  Regalia: m.series_regalia,
+  Omega: m.series_omega,
+  'Olden Primal': m.series_olden_primal,
+  Hollowsky: m.series_hollowsky,
+  Xeno: m.series_xeno,
+  Rose: m.series_rose,
+  Ultima: m.series_ultima,
+  Bahamut: m.series_bahamut,
+  Epic: m.series_epic,
+  Cosmos: m.series_cosmos,
+  Superlative: m.series_superlative,
+  Vintage: m.series_vintage,
+  'Class Champion': m.series_class_champion,
+  Replica: m.series_replica,
+  Relic: m.series_relic,
+  Rusted: m.series_rusted,
+  Sephira: m.series_sephira,
+  Vyrmament: m.series_vyrmament,
+  Upgrader: m.series_upgrader,
+  Astral: m.series_astral,
+  Draconic: m.series_draconic,
+  'Eternal Splendor': m.series_eternal_splendor,
+  Ancestral: m.series_ancestral,
+  'New World Foundation': m.series_new_world,
+  Ennead: m.series_ennead,
+  Militis: m.series_militis,
+  Malice: m.series_malice,
+  Menace: m.series_menace,
+  Illustrious: m.series_illustrious,
+  Proven: m.series_proven,
+  Revans: m.series_revans,
+  World: m.series_world,
+  Exo: m.series_exo,
+  'Draconic Providence': m.series_draconic_providence,
+  Celestial: m.series_celestial,
+  'Omega Rebirth': m.series_omega_rebirth,
+  Collab: m.series_collab,
+  Destroyer: m.series_destroyer
+}
+
+const SUMMON_SERIES: Record<string, () => string> = {
+  Providence: m.series_providence,
+  Genesis: m.series_genesis,
+  Magna: m.series_magna,
+  Optimus: m.series_optimus,
+  'Demi Optimus': m.series_demi_optimus,
+  Archangel: m.series_archangel,
+  Arcarum: m.series_arcarum,
+  Epic: m.series_epic,
+  Carbuncle: m.series_carbuncle,
+  Dynamis: m.series_dynamis,
+  Cryptid: m.series_cryptid,
+  'Six Dragons': m.series_six_dragons,
+  Summer: m.series_summer,
+  Yukata: m.series_yukata,
+  Holiday: m.series_holiday,
+  Collab: m.series_collab,
+  Bellum: m.series_bellum,
+  Crest: m.series_crest,
+  Robur: m.series_robur
+}
+
+const CHARACTER_SERIES: Record<string, () => string> = {
+  Summer: m.series_summer,
+  Yukata: m.series_yukata,
+  Valentine: m.series_valentine,
+  Halloween: m.series_halloween,
+  Holiday: m.series_holiday,
+  Zodiac: m.series_zodiac,
+  Grand: m.series_grand,
+  Fantasy: m.series_fantasy,
+  Collab: m.series_collab,
+  Eternal: m.series_eternal,
+  Evoker: m.series_evoker,
+  Saint: m.series_saint,
+  Formal: m.series_formal
+}
+
+const ELEMENT_NAMES: Record<string, () => string> = {
+  fire: m.element_fire,
+  water: m.element_water,
+  earth: m.element_earth,
+  wind: m.element_wind,
+  light: m.element_light,
+  dark: m.element_dark
+}
+
+const PROFICIENCY_NAMES: Record<string, () => string> = {
+  sabre: m.proficiency_sabre,
+  dagger: m.proficiency_dagger,
+  axe: m.proficiency_axe,
+  spear: m.proficiency_spear,
+  bow: m.proficiency_bow,
+  staff: m.proficiency_staff,
+  melee: m.proficiency_melee,
+  harp: m.proficiency_harp,
+  gun: m.proficiency_gun,
+  katana: m.proficiency_katana
+}
+
+export function translateSeries(
+  englishName: string,
+  type: 'weapon' | 'summon' | 'character'
+): string {
+  if (getLocale() === 'en') return englishName
+
+  let map: Record<string, () => string>
+  if (type === 'weapon') map = WEAPON_SERIES
+  else if (type === 'summon') map = SUMMON_SERIES
+  else if (type === 'character') map = CHARACTER_SERIES
+  else return englishName
+
+  const fn = map[englishName]
+  return fn ? fn() : englishName
+}
+
+export function translateElement(englishName: string): string {
+  if (getLocale() === 'en') return englishName
+  const fn = ELEMENT_NAMES[englishName.toLowerCase()]
+  return fn ? fn() : englishName
+}
+
+export function translateProficiency(englishName: string): string {
+  if (getLocale() === 'en') return englishName
+  const fn = PROFICIENCY_NAMES[englishName.toLowerCase()]
+  return fn ? fn() : englishName
 }

--- a/src/lib/mastery.ts
+++ b/src/lib/mastery.ts
@@ -3,7 +3,8 @@
  * Shared between background.ts (parsing game data) and popup.js (display).
  */
 
-import { t, getLocale } from './i18n.js'
+import * as m from '../paraglide/messages.js'
+import { getLocale } from './i18n.js'
 
 // ==========================================
 // CANONICAL ID → NAME MAPPINGS
@@ -51,35 +52,35 @@ export const PERPETUITY_NAMES: Record<number, string> = {
 // DISPLAY NAME MAPPING (English → i18n key)
 // ==========================================
 
-const MASTERY_I18N_KEYS: Record<string, string> = {
-  ATK: 'mastery_atk',
-  HP: 'mastery_hp',
-  'Debuff Success': 'mastery_debuff_success',
-  'Skill DMG Cap': 'mastery_skill_dmg_cap',
-  'C.A. DMG': 'mastery_ca_dmg',
-  'C.A. DMG Cap': 'mastery_ca_dmg_cap',
-  Stamina: 'mastery_stamina',
-  Enmity: 'mastery_enmity',
-  'Critical Hit': 'mastery_critical_hit',
-  'Double Attack': 'mastery_double_attack',
-  'Triple Attack': 'mastery_triple_attack',
-  DEF: 'mastery_def',
-  Healing: 'mastery_healing',
-  'Debuff Resistance': 'mastery_debuff_resistance',
-  Dodge: 'mastery_dodge',
-  'Element ATK': 'mastery_element_atk',
-  'Element Resistance': 'mastery_element_resistance',
-  'Supplemental DMG': 'mastery_supplemental_dmg',
-  'Counters on Dodge': 'mastery_counters_dodge',
-  'Counters on DMG': 'mastery_counters_dmg',
-  'EM Star Cap': 'mastery_em_star_cap',
-  'DMG Cap': 'mastery_dmg_cap'
+const MASTERY_NAMES: Record<string, () => string> = {
+  ATK: m.mastery_atk,
+  HP: m.mastery_hp,
+  'Debuff Success': m.mastery_debuff_success,
+  'Skill DMG Cap': m.mastery_skill_dmg_cap,
+  'C.A. DMG': m.mastery_ca_dmg,
+  'C.A. DMG Cap': m.mastery_ca_dmg_cap,
+  Stamina: m.mastery_stamina,
+  Enmity: m.mastery_enmity,
+  'Critical Hit': m.mastery_critical_hit,
+  'Double Attack': m.mastery_double_attack,
+  'Triple Attack': m.mastery_triple_attack,
+  DEF: m.mastery_def,
+  Healing: m.mastery_healing,
+  'Debuff Resistance': m.mastery_debuff_resistance,
+  Dodge: m.mastery_dodge,
+  'Element ATK': m.mastery_element_atk,
+  'Element Resistance': m.mastery_element_resistance,
+  'Supplemental DMG': m.mastery_supplemental_dmg,
+  'Counters on Dodge': m.mastery_counters_dodge,
+  'Counters on DMG': m.mastery_counters_dmg,
+  'EM Star Cap': m.mastery_em_star_cap,
+  'DMG Cap': m.mastery_dmg_cap
 }
 
 function getDisplayName(englishName: string): string {
   if (getLocale() === 'en') return englishName
-  const key = MASTERY_I18N_KEYS[englishName]
-  if (key) return t(key)
+  const fn = MASTERY_NAMES[englishName]
+  if (fn) return fn()
   return englishName
 }
 

--- a/src/lib/services/chrome-messages.ts
+++ b/src/lib/services/chrome-messages.ts
@@ -1,21 +1,40 @@
 import { formatCacheStatus } from '../cache.js'
-import type { FormattedCacheStatus } from '../types/cache.js'
+import type { CacheStatusInfo, FormattedCacheStatus } from '../types/cache.js'
+import type {
+  CachedDataResponse,
+  UploadPartyResponse,
+  UploadDetailResponse,
+  UploadCollectionResponse,
+  CheckConflictsResponse,
+  PreviewSyncDeletionsResponse,
+  FetchRaidGroupsResponse,
+  FetchPlaylistsResponse,
+  CreatePlaylistResponse,
+  CollectionIdsResponse,
+  CheckVersionResponse
+} from '../types/messages.js'
 
-function send(message: Record<string, unknown>): Promise<any> {
+function send(message: Record<string, unknown>): Promise<unknown> {
   return chrome.runtime.sendMessage(message)
 }
 
 export async function getCacheStatus(): Promise<
   Record<string, FormattedCacheStatus>
 > {
-  const raw = await send({ action: 'getCacheStatus' })
+  const raw = (await send({ action: 'getCacheStatus' })) as Record<
+    string,
+    CacheStatusInfo
+  >
   return formatCacheStatus(raw || {})
 }
 
 export async function getCachedData(
   dataType: string
-): Promise<{ data?: any; error?: string }> {
-  return send({ action: 'getCachedData', dataType })
+): Promise<CachedDataResponse> {
+  return send({
+    action: 'getCachedData',
+    dataType
+  }) as Promise<CachedDataResponse>
 }
 
 export async function uploadPartyData(options: {
@@ -25,7 +44,7 @@ export async function uploadPartyData(options: {
   visibility?: number
   shareWithCrew?: boolean
   playlists?: Array<{ id: string }>
-}): Promise<{ data?: any; error?: string }> {
+}): Promise<UploadPartyResponse> {
   return send({
     action: 'uploadPartyData',
     dataType: options.dataType,
@@ -34,78 +53,89 @@ export async function uploadPartyData(options: {
     visibility: options.visibility,
     shareWithCrew: options.shareWithCrew,
     playlistIds: options.playlists?.map((p) => p.id)
-  })
+  }) as Promise<UploadPartyResponse>
 }
 
 export async function uploadCollectionData(
   dataType: string,
   selectedIndices: number[],
   conflictResolutions?: Record<string, 'import' | 'skip'> | null
-): Promise<{ data?: any; error?: string }> {
+): Promise<UploadCollectionResponse> {
   return send({
     action: 'uploadCollectionData',
     dataType,
     selectedIndices,
     conflictResolutions
-  })
+  }) as Promise<UploadCollectionResponse>
 }
 
 export async function uploadDetailData(
   dataType: string
-): Promise<{ data?: any; error?: string }> {
-  return send({ action: 'uploadDetailData', dataType })
+): Promise<UploadDetailResponse> {
+  return send({
+    action: 'uploadDetailData',
+    dataType
+  }) as Promise<UploadDetailResponse>
 }
 
 export async function uploadCharacterStats(
   selectedIndices: number[]
-): Promise<{ data?: any; error?: string }> {
-  return send({ action: 'uploadCharacterStats', selectedIndices })
+): Promise<UploadCollectionResponse> {
+  return send({
+    action: 'uploadCharacterStats',
+    selectedIndices
+  }) as Promise<UploadCollectionResponse>
 }
 
 export async function checkConflicts(
   dataType: string,
   selectedIndices: number[]
-): Promise<{ data?: { conflicts?: unknown[] }; error?: string }> {
-  return send({ action: 'checkConflicts', dataType, selectedIndices })
+): Promise<CheckConflictsResponse> {
+  return send({
+    action: 'checkConflicts',
+    dataType,
+    selectedIndices
+  }) as Promise<CheckConflictsResponse>
 }
 
 export async function fetchRaidGroups(
   forceRefresh = false
-): Promise<{ data?: unknown[]; error?: string }> {
-  return send({ action: 'fetchRaidGroups', forceRefresh })
+): Promise<FetchRaidGroupsResponse> {
+  return send({
+    action: 'fetchRaidGroups',
+    forceRefresh
+  }) as Promise<FetchRaidGroupsResponse>
 }
 
-export async function fetchUserPlaylists(): Promise<{
-  data?: any
-  error?: string
-}> {
-  return send({ action: 'fetchUserPlaylists' })
+export async function fetchUserPlaylists(): Promise<FetchPlaylistsResponse> {
+  return send({
+    action: 'fetchUserPlaylists'
+  }) as Promise<FetchPlaylistsResponse>
 }
 
 export async function createPlaylist(data: {
   title: string
   description?: string
   visibility?: number
-}): Promise<{ data?: any; error?: string }> {
-  return send({ action: 'createPlaylist', data })
+}): Promise<CreatePlaylistResponse> {
+  return send({
+    action: 'createPlaylist',
+    data
+  }) as Promise<CreatePlaylistResponse>
 }
 
-export async function getCollectionIds(): Promise<{
-  data?: Record<string, Set<string>>
-  error?: string
-}> {
-  return send({ action: 'getCollectionIds' })
+export async function getCollectionIds(): Promise<CollectionIdsResponse> {
+  return send({ action: 'getCollectionIds' }) as Promise<CollectionIdsResponse>
 }
 
 export async function clearCache(): Promise<void> {
   await send({ action: 'clearCache' })
 }
 
-export async function checkExtensionVersion(): Promise<{
-  data?: { latest?: string }
-  error?: string
-}> {
-  return send({ action: 'checkExtensionVersion' })
+export async function checkExtensionVersion(): Promise<CheckVersionResponse | null> {
+  return send({
+    action: 'checkExtensionVersion'
+  }) as Promise<CheckVersionResponse | null>
 }
 
 export async function popOutWindow(): Promise<void> {
@@ -114,19 +144,22 @@ export async function popOutWindow(): Promise<void> {
 
 export async function previewSyncDeletions(
   dataType: string
-): Promise<{ data?: any; error?: string }> {
-  return send({ action: 'previewSyncDeletions', dataType })
+): Promise<PreviewSyncDeletionsResponse> {
+  return send({
+    action: 'previewSyncDeletions',
+    dataType
+  }) as Promise<PreviewSyncDeletionsResponse>
 }
 
 export async function syncCollection(
   dataType: string,
   selectedIndices: number[],
   deletionIds: string[]
-): Promise<{ data?: any; error?: string }> {
+): Promise<UploadCollectionResponse> {
   return send({
     action: 'syncCollection',
     dataType,
     selectedIndices,
     deletionIds
-  })
+  }) as Promise<UploadCollectionResponse>
 }

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -1,18 +1,29 @@
 import type { FormattedCacheStatus } from '../types/cache.js'
 
-interface AuthData {
+interface AuthAvatar {
+  picture?: string
+  element?: string
+}
+
+export interface AuthData {
   access_token?: string
   role?: number
   language?: string
   username?: string
-  avatar?: string
+  avatar?: AuthAvatar
+  displayName?: string
   defaultImportVisibility?: number
   hasCrew?: boolean
+  simplePortraits?: boolean
+  user?: {
+    username?: string
+  }
 }
 
-interface RaidSelection {
+export interface RaidSelection {
+  id?: string | number
   slug?: string
-  name?: string | { en?: string }
+  name?: string | { en?: string; ja?: string }
   level?: number
   group?: unknown
 }

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -71,6 +71,7 @@ class AppState {
   conflictResolutions = $state<Record<string, 'import' | 'skip'> | null>(null)
 
   // UI state
+  showingDisclaimer = $state(false)
   profilePopoverOpen = $state(false)
   toastMessage = $state('')
   toastVisible = $state(false)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,7 +10,9 @@ export async function safeGet<T = Record<string, unknown>>(
   keys: string | string[]
 ): Promise<T> {
   try {
-    return (await chrome.storage.local.get(keys)) as T
+    return (await (chrome.storage.local.get(keys) as Promise<
+      Record<string, unknown>
+    >)) as T
   } catch (error) {
     console.error('Storage get failed:', error)
     return {} as T

--- a/src/lib/types/cache.ts
+++ b/src/lib/types/cache.ts
@@ -15,6 +15,8 @@ export interface CacheStatusInfo {
   pageCount?: number
   itemName?: string
   stashName?: string
+  partyName?: string
+  partyId?: string
 }
 
 /** Formatted cache status for display in the UI */

--- a/src/lib/types/messages.ts
+++ b/src/lib/types/messages.ts
@@ -24,3 +24,121 @@ export interface ExtensionResponse<T = unknown> {
   error?: string
   code?: string
 }
+
+// ==========================================
+// Service-layer response types
+// ==========================================
+
+/** Response from getCachedData — shape varies by dataType */
+export interface CachedDataResponse {
+  data?: Record<string, unknown> | Record<number, unknown>
+  error?: string
+  timestamp?: number
+  age?: number
+  dataType?: string
+  pageCount?: number
+  totalItems?: number
+  characterCount?: number
+}
+
+/** Response from uploadPartyData */
+export interface UploadPartyResponse {
+  success?: boolean
+  shortcode?: string
+  url?: string
+  error?: string
+}
+
+/** Response from uploadDetailData */
+export interface UploadDetailResponse {
+  success?: boolean
+  error?: string
+  [key: string]: unknown
+}
+
+/** Response from uploadCollectionData / uploadCharacterStats */
+export interface UploadCollectionResponse {
+  success?: boolean
+  created?: number
+  updated?: number
+  skipped?: number
+  errors?: unknown[]
+  reconciliation?: unknown
+  error?: string
+}
+
+/** Response from checkConflicts */
+export interface CheckConflictsResponse {
+  conflicts?: unknown[]
+  error?: string
+}
+
+/** Response from previewSyncDeletions */
+export interface PreviewSyncDeletionsResponse {
+  willDelete?: unknown[]
+  count?: number
+  error?: string
+}
+
+/** A raid within a raid group */
+export interface RaidEntry {
+  id: string | number
+  name: { en?: string; ja?: string }
+  slug?: string
+  level?: number
+  element?: number
+  group_id?: string | number
+}
+
+/** A raid group from the API */
+export interface RaidGroup {
+  id: string | number
+  name: { en?: string; ja?: string }
+  section: number | string
+  difficulty: number
+  extra?: boolean
+  raids?: RaidEntry[]
+}
+
+/** Response from fetchRaidGroups */
+export interface FetchRaidGroupsResponse {
+  data?: RaidGroup[]
+  error?: string
+}
+
+/** A playlist from the API */
+export interface Playlist {
+  id: string | number
+  title?: string
+  description?: string
+  visibility?: number
+}
+
+/** Response from fetchUserPlaylists */
+export interface FetchPlaylistsResponse {
+  data?: Playlist[] | { results?: Playlist[] }
+  error?: string
+}
+
+/** Response from createPlaylist */
+export interface CreatePlaylistResponse {
+  data?: Playlist
+  error?: string
+}
+
+/** Response from getCollectionIds */
+export interface CollectionIdsResponse {
+  weapons?: string[]
+  summons?: string[]
+  characters?: string[]
+  artifacts?: string[]
+  error?: string
+}
+
+/** Response from checkExtensionVersion */
+export interface CheckVersionResponse {
+  isOutdated?: boolean
+  current?: string
+  latest?: string
+  error?: string
+}


### PR DESCRIPTION
## Summary
- Zero `any` types remaining across the entire codebase (was 87 instances)
- Add 13 response/entity types in `types/messages.ts` (RaidGroup, Playlist, upload responses, etc.)
- Replace `t('key')` registry with direct `m.key()` paraglide calls — bundle drops from 294kB to 197kB
- Tighten ~48 `Record<string, unknown>` return types in `background.ts` with specific interfaces
- Wire up disclaimer overlay (show warning card from profile menu without logging out)
- Wire up conflict resolution modal (review button opens modal, resolutions flow into import)
- Render ConflictModal in App.svelte so it's available globally

## Test plan
- [ ] Build succeeds with no type errors
- [ ] `pnpm exec svelte-check --threshold error` passes with 0 errors
- [ ] All existing functionality works unchanged
- [ ] Disclaimer overlay shows/dismisses correctly from profile menu
- [ ] Conflict review flow opens modal and applies resolutions on import