### PR TITLE
Fix release zip filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,13 @@ jobs:
         env:
           WXT_UNIQUE_KEY: ${{ secrets.EXTENSION_KEY }}
 
+      - name: Rename output
+        run: mv .output/*.zip granblue-team-extension.zip
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: build-${{ github.run_number }}
           name: Build ${{ github.run_number }}
-          files: .output/*.zip
+          files: granblue-team-extension.zip
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- WXT's `pnpm zip` outputs `hensei-extractor-2.1.0-chrome.zip` but the download link on /extension expects `granblue-team-extension.zip`
- Rename the output after build so the existing download URL works again

## Test plan
- [ ] Merge and confirm the release asset is named `granblue-team-extension.zip`
- [ ] Verify the download button on /extension works