### PR TITLE
fix raid not saved on party import

### DIFF
--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -840,7 +840,6 @@ interface BackgroundMessage {
   action: string
   dataType?: string
   data?: unknown
-  raidSlug?: string
   raidId?: string
   playlistIds?: string[]
   name?: string
@@ -932,7 +931,7 @@ chrome.runtime.onMessage.addListener(
           }
           uploadPartyData(
             data,
-            message.raidSlug || message.raidId,
+            message.raidId,
             message.playlistIds,
             message.name,
             message.visibility,

--- a/src/lib/services/chrome-messages.ts
+++ b/src/lib/services/chrome-messages.ts
@@ -44,7 +44,7 @@ export async function getCachedData(
 export async function uploadPartyData(options: {
   dataType: string
   name?: string
-  raid?: { slug?: string }
+  raid?: { id?: string | number }
   visibility?: number
   shareWithCrew?: boolean
   playlists?: Array<{ id: string }>
@@ -53,7 +53,7 @@ export async function uploadPartyData(options: {
     action: 'uploadPartyData',
     dataType: options.dataType,
     name: options.name,
-    raidSlug: options.raid?.slug,
+    raidId: options.raid?.id != null ? String(options.raid.id) : undefined,
     visibility: options.visibility,
     shareWithCrew: options.shareWithCrew,
     playlistIds: options.playlists?.map((p) => p.id)


### PR DESCRIPTION
## Summary

Raid selection from the `RaidPicker` was silently dropped on party finalize. The extension sent the raid's slug under the field name `raid_id`, but the API's import endpoint looks it up via `Raid.find_by(id: raid_id)` — a UUID lookup that returns nil for slugs, so `assign_raid` no-oped.

Now we send the raid's UUID.

- `uploadPartyData` accepts `{ id }` instead of `{ slug }` and sends `raidId`
- Drop the orphaned `raidSlug` message field and fallback

Pairs with hensei-api PR that also accepts slugs as a fallback.

## Test plan

- [ ] Load unpacked extension, open a GBF party, pick a raid, import
- [ ] Confirm outgoing `/import` POST has `raid_id` = UUID
- [ ] Confirm raid shows up on resulting team page
- [ ] Import without picking a raid — auto-detect still runs