### PR TITLE
fix manifest version + report it on every API call

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
         run: pnpm zip
         env:
           WXT_UNIQUE_KEY: ${{ secrets.EXTENSION_KEY }}
+          WXT_BUILD_NUMBER: ${{ github.run_number }}
 
       - name: Rename output
         run: mv .output/*.zip granblue-team-extension.zip

--- a/src/components/detail/DetailView.svelte
+++ b/src/components/detail/DetailView.svelte
@@ -3,7 +3,7 @@
   import * as m from '../../paraglide/messages.js'
   import { app } from '../../lib/state/app.svelte.js'
   import { slideRight } from '../../lib/transitions.js'
-  import { getApiUrl } from '../../lib/constants.js'
+  import { apiFetch, getApiUrl } from '../../lib/constants.js'
   import {
     isCollectionType,
     isDatabaseDetailType,
@@ -320,7 +320,7 @@
     if (!name) return null
     try {
       const apiUrl = await getApiUrl('/search/summons')
-      const response = await fetch(apiUrl, {
+      const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ search: { query: name } })
@@ -340,8 +340,8 @@
     try {
       const locale = getLocale()
       const [skillMapRes, weaponKeysRes] = await Promise.all([
-        fetch(await getApiUrl('/weapon_keys/skill_map')),
-        fetch(await getApiUrl('/weapon_keys'))
+        apiFetch(await getApiUrl('/weapon_keys/skill_map')),
+        apiFetch(await getApiUrl('/weapon_keys'))
       ])
       if (!skillMapRes.ok || !weaponKeysRes.ok) return null
       const skillMap: Record<string, string> = await skillMapRes.json()
@@ -369,7 +369,7 @@
     if (_weaponStatModCache) return _weaponStatModCache
     try {
       const apiUrl = await getApiUrl('/weapon_stat_modifiers')
-      const response = await fetch(apiUrl)
+      const response = await apiFetch(apiUrl)
       if (!response.ok) return null
       const modifiers = await response.json() as Array<{ slug: string; name_en: string; name_jp: string; suffix?: string }>
       _weaponStatModCache = {} as Record<string, WeaponStatModifier>
@@ -394,7 +394,7 @@
     }
     try {
       const apiUrl = await getApiUrl('/job_skills/resolve')
-      const response = await fetch(apiUrl, {
+      const response = await apiFetch(apiUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ names: uncached })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@
  * Handles login and user information requests to the Granblue Team API.
  */
 
-import { getApiUrl, getEnvConfig } from './constants.js'
+import { apiFetch, getApiUrl, getEnvConfig } from './constants.js'
 
 interface ApiError extends Error {
   code: string
@@ -44,7 +44,7 @@ async function authenticatedFetch(
     headers['Content-Type'] = 'application/json'
   }
 
-  const response = await fetch(apiUrl, {
+  const response = await apiFetch(apiUrl, {
     method: options.method ?? 'GET',
     headers,
     ...(options.body ? { body: JSON.stringify(options.body) } : {})
@@ -65,7 +65,7 @@ export async function performLogin(
 ): Promise<AuthData> {
   const config = await getEnvConfig()
 
-  const response = await fetch(`${config.apiUrl}/oauth/token`, {
+  const response = await apiFetch(`${config.apiUrl}/oauth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  apiFetch,
   getApiUrl,
   getSiteBaseUrl,
   CACHE_KEYS,
@@ -801,7 +802,7 @@ async function cacheGuildInfo(
 async function checkExtensionVersion(): Promise<VersionCheckResult | null> {
   try {
     const apiUrl = await getApiUrl('/version')
-    const response = await fetch(apiUrl)
+    const response = await apiFetch(apiUrl)
     if (!response.ok) return null
 
     const data = (await response.json()) as {
@@ -1398,7 +1399,7 @@ async function authenticatedPost(
 
   const apiUrl = await getApiUrl(endpoint)
   try {
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1799,7 +1800,7 @@ async function handleCreateCrew(
 async function handleFetchLatestGwEvent(): Promise<FetchLatestGwEventResponse> {
   try {
     const apiUrl = await getApiUrl('/gw_events/status')
-    const response = await fetch(apiUrl)
+    const response = await apiFetch(apiUrl)
     if (!response.ok) return { error: 'request_failed' }
 
     const data = (await response.json()) as {
@@ -1841,7 +1842,7 @@ async function fetchUserPlaylists(): Promise<FetchPlaylistsResult> {
     const auth = await getAuthToken()
     if (!auth) return { error: 'not_logged_in' }
 
-    const response = await fetch(
+    const response = await apiFetch(
       await getApiUrl(`/users/${auth.user.username}/playlists?per_page=100`),
       {
         headers: { Authorization: `Bearer ${auth.access_token}` }
@@ -1898,7 +1899,7 @@ async function fetchRaidGroups(
 
   const apiUrl = await getApiUrl('/raid_groups')
   try {
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${auth.access_token}`
@@ -1944,7 +1945,7 @@ async function getCollectionIds(): Promise<{
 
   const apiUrl = await getApiUrl(`/users/${userId}/collection/game_ids`)
   try {
-    const response = await fetch(apiUrl, {
+    const response = await apiFetch(apiUrl, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${auth.access_token}`

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -55,6 +55,15 @@ export async function getSiteBaseUrl(): Promise<string> {
   return config.siteUrl
 }
 
+export function apiFetch(
+  input: string | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(init.headers)
+  headers.set('X-Extension-Version', chrome.runtime.getManifest().version)
+  return fetch(input, { ...init, headers })
+}
+
 // ==========================================
 // CACHE CONFIGURATION
 // ==========================================

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
     name: 'granblue.team',
     description:
       'Passively captures Granblue Fantasy data for export to granblue.team',
+    version: process.env.WXT_BUILD_NUMBER ?? '0',
     permissions: ['storage', 'debugger', 'tabs', 'sidePanel', 'cookies'],
     host_permissions: [
       'https://game.granbluefantasy.jp/*',


### PR DESCRIPTION
## Summary
- The manifest version was stuck at 2.1.0 because the WXT migration removed the old `manifest.template.json` injection without replacement; WXT was falling back to `package.json`. `wxt.config.ts` now reads `WXT_BUILD_NUMBER`, and the release workflow passes `github.run_number` so each release ships as that build number (locally builds as `0`).
- Adds an `apiFetch()` wrapper in `constants.ts` that sets `X-Extension-Version: chrome.runtime.getManifest().version` on every request to the API. Migrated the existing fetch sites in `auth.ts`, `background.ts`, and `DetailView.svelte`.

The header is consumed by hensei-api in https://github.com/jedmund/hensei-api/pull/new/jedmund/track-extension-version to populate `users.last_extension_version`.

## Test plan
- [x] `pnpm zip` locally → manifest reports `version: "0"`
- [x] `WXT_BUILD_NUMBER=99 pnpm zip` → manifest reports `version: "99"`
- [x] `pnpm build` clean, `pnpm lint` 0 errors
- [ ] After merge: trigger workflow, confirm released zip's manifest has `version` matching `github.run_number`
- [ ] Load unpacked, sign in, open sidepanel, confirm DevTools shows `X-Extension-Version` on requests to `*.granblue.team`