### PR TITLE
show pending collection updates with per-item deltas

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -113,6 +113,8 @@
   "section_will_import": "Will import",
   "section_will_update": "Will update",
   "section_already_owned": "Already in your collection",
+  "section_has_updates": "Updates available",
+  "section_unchanged": "Up to date",
   "section_level_1": "Level 1",
   "stat_name": "Name",
   "stat_id": "ID",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -113,6 +113,8 @@
   "section_will_import": "インポート予定",
   "section_will_update": "更新予定",
   "section_already_owned": "コレクションに登録済み",
+  "section_has_updates": "更新あり",
+  "section_unchanged": "最新",
   "section_level_1": "レベル1",
   "stat_name": "名前",
   "stat_id": "ID",

--- a/src/components/detail/DetailView.svelte
+++ b/src/components/detail/DetailView.svelte
@@ -15,12 +15,12 @@
     getOwnershipId,
     isLevel1
   } from '../../lib/detail-helpers.js'
-  import { getCachedData, fetchRaidGroups, getCollectionIds } from '../../lib/services/chrome-messages.js'
+  import { getCachedData, fetchRaidGroups, fetchElementVariants, getCollectionIds, checkCollectionUpdates, checkCharacterStatsUpdates } from '../../lib/services/chrome-messages.js'
   import { translateError, getLocale } from '../../lib/i18n.js'
 
   import { onMount } from 'svelte'
   import type { RawGameItem } from '../../lib/detail-helpers.js'
-  import type { RaidGroup } from '../../lib/types/messages.js'
+  import type { RaidGroup, CollectionUpdate } from '../../lib/types/messages.js'
 
   import NavigationBar from '../shared/NavigationBar.svelte'
   import Icon from '../shared/Icon.svelte'
@@ -106,6 +106,9 @@
   let ownedIds = $state<Set<string>>(new Set())
   let ownershipLoaded = $state(false)
 
+  // Pending per-item field deltas from check_updates
+  let collectionUpdates = $state<Map<string, CollectionUpdate>>(new Map())
+
   // Supplementary data for parties
   let friendSummon = $state<SummonSearchResult | null>(null)
   let weaponKeyMap = $state<Record<string, { slug: string; name: string }> | null>(null)
@@ -121,8 +124,7 @@
     const allItems = extractItems(dataType, app.detailData as Record<string, unknown>)
     return allItems
       .map((item: RawGameItem, index: number) => ({ item, originalIndex: index }))
-      .filter(({ item, originalIndex }) => {
-        if (app.brokenImageIndices.has(originalIndex)) return false
+      .filter(({ item }) => {
         if (isWeaponOrSummonCollection(dataType) || isCharacterCollection(dataType)) {
           const rarity = item.master?.rarity?.toString() || item.rarity?.toString()
           if (rarity && !app.activeRarityFilters.has(rarity)) return false
@@ -142,7 +144,8 @@
   let categorizedSections = $derived.by((): CategorySection[] => {
     if (!isCollection || filteredItems.length === 0) return []
     const willImport: ItemEntry[] = []
-    const alreadyOwned: ItemEntry[] = []
+    const hasUpdates: ItemEntry[] = []
+    const unchanged: ItemEntry[] = []
     const level1: ItemEntry[] = []
 
     const showLv1Section = isWeaponOrSummonCollection(dataType)
@@ -152,7 +155,11 @@
       if (showLv1Section && isLevel1(entry.item)) {
         level1.push(entry)
       } else if (ownershipId && ownedIds.has(ownershipId)) {
-        alreadyOwned.push(entry)
+        if (ownershipId && collectionUpdates.has(ownershipId)) {
+          hasUpdates.push(entry)
+        } else {
+          unchanged.push(entry)
+        }
       } else {
         willImport.push(entry)
       }
@@ -162,8 +169,11 @@
     if (willImport.length > 0) {
       sections.push({ key: 'will_import', label: m.section_will_import(), items: willImport, defaultExpanded: true })
     }
-    if (alreadyOwned.length > 0) {
-      sections.push({ key: 'already_owned', label: m.section_already_owned(), items: alreadyOwned, defaultExpanded: willImport.length === 0 })
+    if (hasUpdates.length > 0) {
+      sections.push({ key: 'has_updates', label: m.section_has_updates(), items: hasUpdates, defaultExpanded: true })
+    }
+    if (unchanged.length > 0) {
+      sections.push({ key: 'unchanged', label: m.section_unchanged(), items: unchanged, defaultExpanded: willImport.length === 0 && hasUpdates.length === 0 })
     }
     if (level1.length > 0) {
       sections.push({ key: 'level_1', label: m.section_level_1(), items: level1, defaultExpanded: false })
@@ -181,10 +191,10 @@
     if (!isCollection || !ownershipLoaded || categorizedSections.length === 0) return
     if (lastInitDataType === dataType) return
     lastInitDataType = dataType
-    const willImportSection = categorizedSections.find((s) => s.key === 'will_import')
     const next = new Set<number>()
-    if (willImportSection) {
-      for (const { originalIndex } of willImportSection.items) {
+    for (const section of categorizedSections) {
+      if (section.key !== 'will_import' && section.key !== 'has_updates') continue
+      for (const { originalIndex } of section.items) {
         if (!app.manuallyUnchecked.has(originalIndex)) {
           next.add(originalIndex)
         }
@@ -226,6 +236,10 @@
       }
     }
     chrome.runtime.onMessage.addListener(onMessage)
+    // Warm the element-variant map so weapon image fallbacks are ready before
+    // the first render. Cached with a long TTL in background.ts; this is a no-op
+    // on cache hit.
+    void fetchElementVariants()
     return () => chrome.runtime.onMessage.removeListener(onMessage)
   })
 
@@ -246,6 +260,9 @@
     // Fetch ownership for collection categorization
     if (isCollectionType(dt) && dt !== 'character_stats') {
       await loadOwnedIds(dt)
+      await loadCollectionUpdates(dt)
+    } else if (dt === 'character_stats') {
+      await loadCharacterStatsUpdates()
     }
 
     if (dt.startsWith('party_')) {
@@ -290,6 +307,47 @@
       ownedIds = new Set()
     } finally {
       ownershipLoaded = true
+    }
+  }
+
+  async function loadCollectionUpdates(dt: string) {
+    // Artifacts don't support partial updates; skip them.
+    if (dt.includes('artifact')) {
+      collectionUpdates = new Map()
+      return
+    }
+    try {
+      const response = await checkCollectionUpdates(dt)
+      if (response.error || !response.updates) {
+        collectionUpdates = new Map()
+        return
+      }
+      const map = new Map<string, CollectionUpdate>()
+      for (const update of response.updates) {
+        const key = update.game_id ?? update.granblue_id
+        if (key) map.set(key, update)
+      }
+      collectionUpdates = map
+    } catch {
+      collectionUpdates = new Map()
+    }
+  }
+
+  async function loadCharacterStatsUpdates() {
+    try {
+      const response = await checkCharacterStatsUpdates()
+      if (response.error || !response.updates) {
+        collectionUpdates = new Map()
+        return
+      }
+      const map = new Map<string, CollectionUpdate>()
+      for (const update of response.updates) {
+        const key = update.granblue_id
+        if (key) map.set(key, update)
+      }
+      collectionUpdates = map
+    } catch {
+      collectionUpdates = new Map()
     }
   }
 
@@ -519,6 +577,7 @@
                 {dataType}
                 {isCollection}
                 {simplePortraits}
+                {collectionUpdates}
               />
             {:else}
               <ItemGrid
@@ -527,6 +586,7 @@
                 {isCollection}
                 {simplePortraits}
                 {weaponStatModifiers}
+                {collectionUpdates}
               />
             {/if}
           </CollapsibleSection>
@@ -537,6 +597,7 @@
           {dataType}
           {isCollection}
           {simplePortraits}
+          {collectionUpdates}
         />
       {:else}
         <ItemGrid
@@ -545,6 +606,7 @@
           {isCollection}
           {simplePortraits}
           {weaponStatModifiers}
+          {collectionUpdates}
         />
       {/if}
     {/if}

--- a/src/components/detail/items/ItemGrid.svelte
+++ b/src/components/detail/items/ItemGrid.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { app } from '../../../lib/state/app.svelte.js'
-  import { getItemImageUrl, getGridClass, getCharacterModifiers, getWeaponModifiers, isWeaponOrSummonCollection, resolveAwakeningIcon, resolveAugmentIcon, buildAxTooltipLines, type WeaponStatModifier } from '../../../lib/detail-helpers.js'
+  import { getItemImageUrl, getItemImageFallbackUrl, getGridClass, getCharacterModifiers, getWeaponModifiers, getOwnershipId, isWeaponOrSummonCollection, resolveAwakeningIcon, resolveAugmentIcon, buildAxTooltipLines, type WeaponStatModifier } from '../../../lib/detail-helpers.js'
   import { getImageUrl } from '../../../lib/constants.js'
   import { getLocale } from '../../../lib/i18n.js'
   import * as m from '../../../paraglide/messages.js'
   import type { RawGameItem } from '../../../lib/detail-helpers.js'
+  import type { CollectionUpdate } from '../../../lib/types/messages.js'
   import Icon from '../../shared/Icon.svelte'
   import Tooltip from '../../shared/Tooltip.svelte'
   import RichTooltip from '../../shared/RichTooltip.svelte'
@@ -15,13 +16,37 @@
     isCollection: boolean
     simplePortraits?: boolean
     weaponStatModifiers?: Record<string, WeaponStatModifier> | null
+    collectionUpdates?: Map<string, CollectionUpdate>
   }
 
-  let { items, dataType, isCollection, simplePortraits = false, weaponStatModifiers = null }: Props = $props()
+  let { items, dataType, isCollection, simplePortraits = false, weaponStatModifiers = null, collectionUpdates = new Map() }: Props = $props()
+
+  function getUpdate(item: RawGameItem): CollectionUpdate | undefined {
+    const key = getOwnershipId(dataType, item)
+    if (!key) return undefined
+    return collectionUpdates.get(key)
+  }
 
   let gridClass = $derived(getGridClass(dataType))
   let isCharacterType = $derived(dataType.includes('npc') || dataType.includes('character'))
   let isWeaponType = $derived(dataType.includes('weapon') || dataType.startsWith('stash_weapon'))
+
+  // Per-item element-variant fallback URLs (resolved asynchronously from the
+  // cached /weapons/element_variants map). Keyed by originalIndex.
+  let variantFallbackUrls = $state<Map<number, string>>(new Map())
+
+  $effect(() => {
+    const currentItems = items
+    currentItems.forEach(({ item, originalIndex }) => {
+      if (variantFallbackUrls.has(originalIndex)) return
+      void getItemImageFallbackUrl(dataType, item).then((url) => {
+        if (!url) return
+        const next = new Map(variantFallbackUrls)
+        next.set(originalIndex, url)
+        variantFallbackUrls = next
+      })
+    })
+  })
 
   function toggleItem(index: number) {
     const next = new Set(app.selectedItems)
@@ -39,85 +64,119 @@
 
   function handleImageError(index: number, e: Event) {
     const img = e.target as HTMLImageElement
-    const fallbackSrc = img.src.replace(/_\d+\.jpg$/, '.jpg')
-    if (img.src !== fallbackSrc && !img.dataset.fallbackAttempted) {
-      img.dataset.fallbackAttempted = 'true'
-      img.src = fallbackSrc
-      return
+    const stage = img.dataset.fallbackStage ?? '0'
+
+    if (stage === '0') {
+      const stripped = img.src.replace(/_\d+\.jpg$/, '.jpg')
+      if (stripped !== img.src) {
+        img.dataset.fallbackStage = '1'
+        img.src = stripped
+        return
+      }
     }
-    const broken = new Set(app.brokenImageIndices)
-    broken.add(index)
-    app.brokenImageIndices = broken
-    const selected = new Set(app.selectedItems)
-    selected.delete(index)
-    app.selectedItems = selected
+
+    if (stage === '0' || stage === '1') {
+      const variantFallback = variantFallbackUrls.get(index)
+      if (variantFallback && variantFallback !== img.src) {
+        img.dataset.fallbackStage = '2'
+        img.src = variantFallback
+        return
+      }
+    }
+
+    img.dataset.fallbackStage = 'final'
+    img.classList.add('image-failed')
   }
 </script>
 
 <div class="item-grid {gridClass} square-cells">
   {#each items as { item, originalIndex } (originalIndex)}
-    {#if !app.brokenImageIndices.has(originalIndex)}
-      <!-- svelte-ignore a11y_click_events_have_key_events -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="grid-item"
-        class:selectable={isCollection}
-        data-index={originalIndex}
-        onclick={() => isCollection && toggleItem(originalIndex)}
-      >
-        {#if isCharacterType}
-          {@const charMods = getCharacterModifiers(item)}
-          {#if charMods.perpetuity}
-            <div class="char-modifiers">
-              <Tooltip content={m.stat_perpetuity_ring()}><img class="perpetuity-ring" src="icons/perpetuity/filled.svg" alt={m.stat_perpetuity_ring()}></Tooltip>
-            </div>
-          {/if}
-        {:else if isWeaponType}
-          {@const wMods = getWeaponModifiers(item)}
-          {#if wMods.awakening || wMods.axSkill || wMods.befoulment || wMods.weaponKeys.length > 0}
-            <div class="weapon-modifiers">
-              {#if wMods.awakening}
-                <Tooltip content="{wMods.awakening.form_name} Lv.{wMods.awakening.level}"><img class="awakening-icon" src={getImageUrl(`awakening/${resolveAwakeningIcon(wMods.awakening.form_name)}.png`)} alt={m.stat_awakening()}></Tooltip>
-              {/if}
-              {#if wMods.axSkill || wMods.befoulment || wMods.weaponKeys.length > 0}
-                <div class="weapon-skills">
-                  {#if wMods.axSkill}
-                    {@const axIconFile = resolveAugmentIcon(wMods.axSkill.iconImage || 'ex_skill_atk')}
-                    <RichTooltip>
-                      {#snippet content()}{#each buildAxTooltipLines(wMods.axSkill!.skill, wMods.axSkill!.iconImage, weaponStatModifiers, getLocale()) as line}<div>{line}</div>{/each}{/snippet}
-                      <img class="ax-skill-icon" src={getImageUrl(`ax/${axIconFile}.png`)} alt={m.stat_ax_skills()}>
-                    </RichTooltip>
-                  {/if}
-                  {#if wMods.befoulment}
-                    {@const befoulIconFile = resolveAugmentIcon(wMods.befoulment.iconImage || 'ex_skill_def_down')}
-                    <RichTooltip>
-                      {#snippet content()}<div>{m.stat_befoulment()}: {wMods.befoulment!.skill?.show_value || 'Befouled'}</div><div>{m.stat_exorcism()} {wMods.befoulment!.exorcismLevel}/{wMods.befoulment!.maxExorcismLevel}</div>{/snippet}
-                      <img class="befoulment-icon" src={getImageUrl(`ax/${befoulIconFile}.png`)} alt={m.stat_befoulment()}>
-                    </RichTooltip>
-                  {/if}
-                  {#each wMods.weaponKeys as slug}
-                    <Tooltip content={slug}><img class="weapon-key-icon" src={getImageUrl(`weapon-keys/${slug}.png`)} alt={slug}></Tooltip>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          {/if}
+    {@const pendingUpdate = getUpdate(item)}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="grid-item"
+      class:selectable={isCollection}
+      class:has-update={!!pendingUpdate}
+      data-index={originalIndex}
+      onclick={() => isCollection && toggleItem(originalIndex)}
+    >
+      {#if isCharacterType}
+        {@const charMods = getCharacterModifiers(item)}
+        {#if charMods.perpetuity}
+          <div class="char-modifiers">
+            <Tooltip content={m.stat_perpetuity_ring()}><img class="perpetuity-ring" src="icons/perpetuity/filled.svg" alt={m.stat_perpetuity_ring()}></Tooltip>
+          </div>
         {/if}
+      {:else if isWeaponType}
+        {@const wMods = getWeaponModifiers(item)}
+        {#if wMods.awakening || wMods.axSkill || wMods.befoulment || wMods.weaponKeys.length > 0}
+          <div class="weapon-modifiers">
+            {#if wMods.awakening}
+              <Tooltip content="{wMods.awakening.form_name} Lv.{wMods.awakening.level}"><img class="awakening-icon" src={getImageUrl(`awakening/${resolveAwakeningIcon(wMods.awakening.form_name)}.png`)} alt={m.stat_awakening()}></Tooltip>
+            {/if}
+            {#if wMods.axSkill || wMods.befoulment || wMods.weaponKeys.length > 0}
+              <div class="weapon-skills">
+                {#if wMods.axSkill}
+                  {@const axIconFile = resolveAugmentIcon(wMods.axSkill.iconImage || 'ex_skill_atk')}
+                  <RichTooltip>
+                    {#snippet content()}{#each buildAxTooltipLines(wMods.axSkill!.skill, wMods.axSkill!.iconImage, weaponStatModifiers, getLocale()) as line}<div>{line}</div>{/each}{/snippet}
+                    <img class="ax-skill-icon" src={getImageUrl(`ax/${axIconFile}.png`)} alt={m.stat_ax_skills()}>
+                  </RichTooltip>
+                {/if}
+                {#if wMods.befoulment}
+                  {@const befoulIconFile = resolveAugmentIcon(wMods.befoulment.iconImage || 'ex_skill_def_down')}
+                  <RichTooltip>
+                    {#snippet content()}<div>{m.stat_befoulment()}: {wMods.befoulment!.skill?.show_value || 'Befouled'}</div><div>{m.stat_exorcism()} {wMods.befoulment!.exorcismLevel}/{wMods.befoulment!.maxExorcismLevel}</div>{/snippet}
+                    <img class="befoulment-icon" src={getImageUrl(`ax/${befoulIconFile}.png`)} alt={m.stat_befoulment()}>
+                  </RichTooltip>
+                {/if}
+                {#each wMods.weaponKeys as slug}
+                  <Tooltip content={slug}><img class="weapon-key-icon" src={getImageUrl(`weapon-keys/${slug}.png`)} alt={slug}></Tooltip>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      {/if}
+      {#if pendingUpdate}
+        <RichTooltip>
+          {#snippet content()}
+            <div class="update-tooltip">
+              <div class="update-tooltip-title">{m.section_has_updates()}</div>
+              {#each pendingUpdate.changes as change}
+                <div class="update-tooltip-row">
+                  <span class="update-tooltip-label">{change.label}</span>
+                  <span class="update-tooltip-values">
+                    {change.before.display || '—'} → {change.after.display || '—'}
+                  </span>
+                </div>
+              {/each}
+            </div>
+          {/snippet}
+          <img
+            src={getItemImageUrl(dataType, item, simplePortraits)}
+            alt=""
+            onerror={(e) => handleImageError(originalIndex, e)}
+          />
+        </RichTooltip>
+        <span class="update-indicator" aria-hidden="true"></span>
+      {:else}
         <img
           src={getItemImageUrl(dataType, item, simplePortraits)}
           alt=""
-          onerror={(e) => isCollection && handleImageError(originalIndex, e)}
+          onerror={(e) => handleImageError(originalIndex, e)}
         />
-        {#if isCollection}
-          <label
-            class="item-checkbox"
-            class:checked={app.selectedItems.has(originalIndex)}
-            data-index={originalIndex}
-          >
-            <span class="checkbox-indicator"><Icon name="check" size={14} /></span>
-          </label>
-        {/if}
-      </div>
-    {/if}
+      {/if}
+      {#if isCollection}
+        <label
+          class="item-checkbox"
+          class:checked={app.selectedItems.has(originalIndex)}
+          data-index={originalIndex}
+        >
+          <span class="checkbox-indicator"><Icon name="check" size={14} /></span>
+        </label>
+      {/if}
+    </div>
   {/each}
 </div>

--- a/src/components/detail/items/ItemList.svelte
+++ b/src/components/detail/items/ItemList.svelte
@@ -1,19 +1,29 @@
 <script lang="ts">
   import { app } from '../../../lib/state/app.svelte.js'
-  import { getItemImageUrl, getArtifactLabels } from '../../../lib/detail-helpers.js'
+  import { getItemImageUrl, getArtifactLabels, getOwnershipId } from '../../../lib/detail-helpers.js'
+  import * as m from '../../../paraglide/messages.js'
   import type { RawGameItem } from '../../../lib/detail-helpers.js'
+  import type { CollectionUpdate } from '../../../lib/types/messages.js'
   import Icon from '../../shared/Icon.svelte'
+  import RichTooltip from '../../shared/RichTooltip.svelte'
 
   interface Props {
     items: Array<{ item: RawGameItem; originalIndex: number }>
     dataType: string
     isCollection: boolean
     simplePortraits?: boolean
+    collectionUpdates?: Map<string, CollectionUpdate>
   }
 
-  let { items, dataType, isCollection, simplePortraits = false }: Props = $props()
+  let { items, dataType, isCollection, simplePortraits = false, collectionUpdates = new Map() }: Props = $props()
 
   let isArtifactType = $derived(dataType.includes('artifact'))
+
+  function getUpdate(item: RawGameItem): CollectionUpdate | undefined {
+    const key = getOwnershipId(dataType, item)
+    if (!key) return undefined
+    return collectionUpdates.get(key)
+  }
 
   function toggleItem(index: number) {
     const next = new Set(app.selectedItems)
@@ -32,21 +42,47 @@
 
 <div class="item-list">
   {#each items as { item, originalIndex } (originalIndex)}
+    {@const pendingUpdate = getUpdate(item)}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="list-item"
       class:selectable={isCollection}
+      class:has-update={!!pendingUpdate}
       data-index={originalIndex}
       onclick={() => isCollection && toggleItem(originalIndex)}
     >
-      <img
-        class="list-item-image"
-        src={getItemImageUrl(dataType, item, simplePortraits)}
-        alt=""
-      />
+      {#if pendingUpdate}
+        <RichTooltip>
+          {#snippet content()}
+            <div class="update-tooltip">
+              <div class="update-tooltip-title">{m.section_has_updates()}</div>
+              {#each pendingUpdate.changes as change}
+                <div class="update-tooltip-row">
+                  <span class="update-tooltip-label">{change.label}</span>
+                  <span class="update-tooltip-values">
+                    {change.before.display || '—'} → {change.after.display || '—'}
+                  </span>
+                </div>
+              {/each}
+            </div>
+          {/snippet}
+          <img
+            class="list-item-image"
+            src={getItemImageUrl(dataType, item, simplePortraits)}
+            alt=""
+          />
+        </RichTooltip>
+      {:else}
+        <img
+          class="list-item-image"
+          src={getItemImageUrl(dataType, item, simplePortraits)}
+          alt=""
+        />
+      {/if}
       <div class="list-item-info">
         <span class="list-item-name">
+          {#if pendingUpdate}<span class="update-indicator" aria-hidden="true"></span>{/if}
           {item.name || item.master?.name || ''}
           {#if item.level || item.lv}
             <span class="list-item-level">Lv.{item.level || item.lv}</span>

--- a/src/entrypoints/sidepanel/styles/_detail.scss
+++ b/src/entrypoints/sidepanel/styles/_detail.scss
@@ -585,6 +585,56 @@ body.light #playlistCreateSubmit {
   }
 }
 
+/* Pending collection update indicator */
+.grid-item .update-indicator {
+  position: absolute;
+  top: 4cqw;
+  right: 4cqw;
+  width: 16cqw;
+  height: 16cqw;
+  border-radius: 50%;
+  background: var(--color-accent, #3b82f6);
+  box-shadow: 0 0 0 2px var(--color-bg, #fff);
+  pointer-events: none;
+  z-index: 4;
+}
+
+.list-item .update-indicator {
+  width: spacing.$unit;
+  height: spacing.$unit;
+  border-radius: 50%;
+  background: var(--color-accent, #3b82f6);
+  flex-shrink: 0;
+  margin-right: spacing.$unit-half;
+}
+
+.update-tooltip {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$unit-half;
+  min-width: spacing.$unit * 18;
+}
+
+.update-tooltip-title {
+  font-weight: 600;
+  opacity: 0.8;
+  font-size: 0.85em;
+}
+
+.update-tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: spacing.$unit;
+}
+
+.update-tooltip-label {
+  opacity: 0.7;
+}
+
+.update-tooltip-values {
+  font-weight: 500;
+}
+
 /* Item Checkbox */
 .item-checkbox {
   position: absolute;

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -14,6 +14,7 @@ import {
   CACHE_PREFIXES,
   CACHE_TTL_MS,
   RAID_GROUPS_CACHE_TTL_MS,
+  ELEMENT_VARIANTS_CACHE_TTL_MS,
   resolveCacheKey
 } from './constants.js'
 import {
@@ -140,6 +141,11 @@ interface ConflictCheckResult {
   error?: string
 }
 
+interface UpdateCheckResult {
+  updates?: unknown[]
+  error?: string
+}
+
 interface SyncPreviewResult {
   willDelete?: unknown[]
   count?: number
@@ -185,6 +191,11 @@ interface FetchPlaylistsResult {
 }
 
 interface FetchRaidGroupsResult {
+  data?: unknown
+  error?: string
+}
+
+interface FetchElementVariantsResult {
   data?: unknown
   error?: string
 }
@@ -910,6 +921,10 @@ chrome.runtime.onMessage.addListener(
         fetchRaidGroups(message.forceRefresh).then(sendResponse)
         return true
 
+      case 'fetchElementVariants':
+        fetchElementVariants(message.forceRefresh).then(sendResponse)
+        return true
+
       case 'fetchUserPlaylists':
         fetchUserPlaylists().then(sendResponse)
         return true
@@ -967,6 +982,31 @@ chrome.runtime.onMessage.addListener(
           checkConflicts(
             data as Record<number, PageData>,
             message.dataType!
+          ).then(sendResponse)
+        })
+        return true
+
+      case 'checkCollectionUpdates':
+        loadCachedDataForUpload(message.dataType!).then((data) => {
+          if (!data) {
+            sendResponse({ error: 'no_cached_data' })
+            return
+          }
+          checkCollectionUpdates(
+            data as Record<number, PageData>,
+            message.dataType!
+          ).then(sendResponse)
+        })
+        return true
+
+      case 'checkCharacterStatsUpdates':
+        loadCachedDataForUpload('character_stats').then((data) => {
+          if (!data) {
+            sendResponse({ error: 'no_cached_data' })
+            return
+          }
+          checkCharacterStatsUpdates(
+            data as Record<string, CharacterStatsEntry>
           ).then(sendResponse)
         })
         return true
@@ -1565,6 +1605,77 @@ async function checkConflicts(
   return { conflicts: (result.data!.conflicts as unknown[]) ?? [] }
 }
 
+async function checkCollectionUpdates(
+  pagesData: Record<number, PageData>,
+  dataType: string
+): Promise<UpdateCheckResult> {
+  const endpoint = resolveEndpoint(dataType)
+  if (!endpoint) return { error: 'unknown_type' }
+
+  const allItems = collectPageItems(pagesData)
+  if (allItems.length === 0) return { error: 'no_items' }
+
+  const result = await authenticatedPost(
+    `/collection/${endpoint}/check_updates`,
+    { data: { list: allItems } }
+  )
+  if (result.error) return { error: result.error }
+  return { updates: (result.data!.updates as unknown[]) ?? [] }
+}
+
+async function checkCharacterStatsUpdates(
+  statsData: Record<string, CharacterStatsEntry>
+): Promise<UpdateCheckResult> {
+  const items = Object.values(statsData).map((char) => {
+    const item: Record<string, unknown> = { granblue_id: char.masterId }
+
+    if (char.uncapLevel !== undefined) {
+      item.uncap_level = char.uncapLevel
+    }
+    if (char.transcendenceStep !== undefined) {
+      item.transcendence_step = char.transcendenceStep
+    }
+
+    if (char.awakening) {
+      item.awakening_type = char.awakening.type
+      item.awakening_level = char.awakening.level
+    }
+
+    if (char.rings && char.rings.length > 0) {
+      char.rings.forEach((ring, i) => {
+        if (ring?.modifier) {
+          item[`ring${i + 1}`] = {
+            modifier: ring.modifier,
+            strength: ring.strength
+          }
+        }
+      })
+    }
+
+    if (char.earring?.modifier) {
+      item.earring = {
+        modifier: char.earring.modifier,
+        strength: char.earring.strength
+      }
+    }
+
+    if (char.perpetuity !== undefined) {
+      item.perpetuity = char.perpetuity
+    }
+
+    return item
+  })
+
+  if (items.length === 0) return { error: 'no_items' }
+
+  const result = await authenticatedPost(
+    '/collection/characters/check_updates',
+    { data: { list: items } }
+  )
+  if (result.error) return { error: result.error }
+  return { updates: (result.data!.updates as unknown[]) ?? [] }
+}
+
 async function uploadCollectionData(
   pagesData: Record<number, PageData>,
   dataType: string,
@@ -1898,6 +2009,51 @@ async function fetchRaidGroups(
   if (!auth) return { error: 'not_logged_in' }
 
   const apiUrl = await getApiUrl('/raid_groups')
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${auth.access_token}`
+      }
+    })
+
+    if (!response.ok) {
+      return { error: await parseErrorResponse(response) }
+    }
+
+    const data = await response.json()
+
+    await chrome.storage.local.set({
+      [cacheKey]: { data, timestamp: Date.now() }
+    })
+
+    return { data }
+  } catch {
+    return { error: 'request_failed' }
+  }
+}
+
+async function fetchElementVariants(
+  forceRefresh = false
+): Promise<FetchElementVariantsResult> {
+  const cacheKey = CACHE_KEYS.element_variants!
+  const result = await chrome.storage.local.get(cacheKey)
+  const cached = result[cacheKey] as
+    | { timestamp: number; data: unknown }
+    | undefined
+
+  if (
+    !forceRefresh &&
+    cached?.timestamp &&
+    Date.now() - cached.timestamp < ELEMENT_VARIANTS_CACHE_TTL_MS
+  ) {
+    return { data: cached.data }
+  }
+
+  const auth = await getAuthToken()
+  if (!auth) return { error: 'not_logged_in' }
+
+  const apiUrl = await getApiUrl('/weapons/element_variants')
   try {
     const response = await fetch(apiUrl, {
       method: 'GET',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -65,6 +65,9 @@ export const CACHE_TTL_MS = 30 * 60 * 1000
 /** How long raid groups cache is considered fresh (1 day) */
 export const RAID_GROUPS_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
+/** How long element-variant map cache is considered fresh (7 days) */
+export const ELEMENT_VARIANTS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
 /** Granblue Fantasy CDN for game assets (new items not yet on S3) */
 export const GBF_CDN =
   'https://prd-game-a-granbluefantasy.akamaized.net/assets_en/img/sp/assets'
@@ -80,6 +83,7 @@ export const CACHE_KEYS: Record<string, string> = {
   collection_artifact: 'gbf_cache_collection_artifact',
   character_stats: 'gbf_cache_character_stats',
   raid_groups: 'gbf_cache_raid_groups',
+  element_variants: 'gbf_cache_element_variants',
   guild_info: 'gbf_cache_guild_info'
 }
 

--- a/src/lib/detail-helpers.ts
+++ b/src/lib/detail-helpers.ts
@@ -15,6 +15,7 @@ import {
   AUGMENT_ICON_MAP,
   resolveForgedSummonId
 } from './game-data.js'
+import { getBaseGranblueIdForVariant } from './element-variants.js'
 import * as m from '../paraglide/messages.js'
 import { translateSeries, getLocale } from './i18n.js'
 
@@ -268,6 +269,27 @@ export function getItemImageUrl(
     return getImageUrl(`artifact-square/${artifactId}.jpg`)
   }
   return ''
+}
+
+/**
+ * Returns a fallback image URL for an item whose primary thumbnail may 404.
+ * Currently only meaningful for element-changeable weapons (Ultima, Atma, CCW,
+ * Superlative): the game sends per-element variant IDs whose thumbnails aren't
+ * uploaded to the S3 bucket. Falling back to the base granblue_id image gives
+ * a generic but present thumbnail so the weapon stays visible and importable.
+ */
+export async function getItemImageFallbackUrl(
+  dataType: string,
+  item: RawGameItem
+): Promise<string | undefined> {
+  if (!(dataType.includes('weapon') || dataType.startsWith('stash_weapon'))) {
+    return undefined
+  }
+  const granblueId = item.master?.id || item.param?.id || item.id
+  if (!granblueId) return undefined
+  const baseId = await getBaseGranblueIdForVariant(String(granblueId))
+  if (!baseId) return undefined
+  return getImageUrl(`weapon-square/${baseId}.jpg`)
 }
 
 export function getArtifactLabels(item: RawGameItem): string {

--- a/src/lib/element-variants.ts
+++ b/src/lib/element-variants.ts
@@ -1,0 +1,67 @@
+/**
+ * Helpers for the element-variant map.
+ *
+ * Element-changeable weapons (Ultima, Atma, CCW, Superlative) have per-element
+ * game variant IDs that aren't uploaded to the S3 image bucket. The hensei-api
+ * exposes the base granblue_id → {element: variantId} map via
+ * GET /weapons/element_variants, which the extension caches in
+ * chrome.storage.local. These helpers read that cache and map a variant game ID
+ * back to its base granblue_id so we can fall back to the base thumbnail when
+ * a variant image 404s.
+ */
+import { CACHE_KEYS } from './constants.js'
+import type { ElementVariantEntry } from './types/messages.js'
+
+let variantToBaseCache: Map<string, string> | null = null
+
+export type { ElementVariantEntry }
+
+export async function getCachedElementVariants(): Promise<
+  ElementVariantEntry[] | null
+> {
+  const cacheKey = CACHE_KEYS.element_variants!
+  const result = await chrome.storage.local.get(cacheKey)
+  const cached = result[cacheKey] as
+    | { timestamp: number; data: ElementVariantEntry[] }
+    | undefined
+  return cached?.data ?? null
+}
+
+function buildVariantToBaseMap(
+  entries: ElementVariantEntry[]
+): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const entry of entries) {
+    const baseId = entry.granblue_id
+    if (!baseId || !entry.element_variant_ids) continue
+    for (const variantId of Object.values(entry.element_variant_ids)) {
+      if (variantId) map.set(variantId, baseId)
+    }
+  }
+  return map
+}
+
+export async function getBaseGranblueIdForVariant(
+  candidateId: string
+): Promise<string | null> {
+  if (!candidateId) return null
+  if (!variantToBaseCache) {
+    const entries = await getCachedElementVariants()
+    if (!entries) return null
+    variantToBaseCache = buildVariantToBaseMap(entries)
+  }
+  return variantToBaseCache.get(candidateId) ?? null
+}
+
+/** Reset the in-memory lookup cache (e.g. after the storage cache is refreshed). */
+export function resetElementVariantsMemo(): void {
+  variantToBaseCache = null
+}
+
+if (typeof chrome !== 'undefined' && chrome.storage?.onChanged) {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes[CACHE_KEYS.element_variants!]) {
+      variantToBaseCache = null
+    }
+  })
+}

--- a/src/lib/services/chrome-messages.ts
+++ b/src/lib/services/chrome-messages.ts
@@ -10,8 +10,10 @@ import type {
   FetchLatestGwEventResponse,
   PreviewGwPhantomsResponse,
   CheckConflictsResponse,
+  CheckUpdatesResponse,
   PreviewSyncDeletionsResponse,
   FetchRaidGroupsResponse,
+  FetchElementVariantsResponse,
   FetchPlaylistsResponse,
   CreatePlaylistResponse,
   CollectionIdsResponse,
@@ -102,6 +104,21 @@ export async function checkConflicts(
   }) as Promise<CheckConflictsResponse>
 }
 
+export async function checkCollectionUpdates(
+  dataType: string
+): Promise<CheckUpdatesResponse> {
+  return send({
+    action: 'checkCollectionUpdates',
+    dataType
+  }) as Promise<CheckUpdatesResponse>
+}
+
+export async function checkCharacterStatsUpdates(): Promise<CheckUpdatesResponse> {
+  return send({
+    action: 'checkCharacterStatsUpdates'
+  }) as Promise<CheckUpdatesResponse>
+}
+
 export async function fetchRaidGroups(
   forceRefresh = false
 ): Promise<FetchRaidGroupsResponse> {
@@ -109,6 +126,15 @@ export async function fetchRaidGroups(
     action: 'fetchRaidGroups',
     forceRefresh
   }) as Promise<FetchRaidGroupsResponse>
+}
+
+export async function fetchElementVariants(
+  forceRefresh = false
+): Promise<FetchElementVariantsResponse> {
+  return send({
+    action: 'fetchElementVariants',
+    forceRefresh
+  }) as Promise<FetchElementVariantsResponse>
 }
 
 export async function fetchUserPlaylists(): Promise<FetchPlaylistsResponse> {

--- a/src/lib/state/app.svelte.ts
+++ b/src/lib/state/app.svelte.ts
@@ -55,7 +55,6 @@ class AppState {
   // Selection
   selectedItems = $state(new Set<number>())
   manuallyUnchecked = $state(new Set<number>())
-  brokenImageIndices = $state(new Set<number>())
 
   // Filters
   activeRarityFilters = $state(new Set(['4']))
@@ -114,7 +113,6 @@ class AppState {
     this.detailData = null
     this.selectedItems = new Set()
     this.manuallyUnchecked = new Set()
-    this.brokenImageIndices = new Set()
     this.enableFullSync = false
     this.partyName = ''
     this.selectedRaid = null

--- a/src/lib/types/messages.ts
+++ b/src/lib/types/messages.ts
@@ -21,6 +21,8 @@ export type ExtensionMessage =
   | { action: 'createCrew'; name: string }
   | { action: 'fetchLatestGwEvent' }
   | { action: 'previewGwPhantoms'; dataType: string }
+  | { action: 'checkCollectionUpdates'; data: unknown; dataType: string }
+  | { action: 'checkCharacterStatsUpdates'; data: unknown }
 
 export interface ExtensionResponse<T = unknown> {
   success: boolean
@@ -77,6 +79,27 @@ export interface CheckConflictsResponse {
   error?: string
 }
 
+/** A single field-level change returned by check_updates */
+export interface CollectionChangeField {
+  field: string
+  label: string
+  before: { raw: unknown; display: string }
+  after: { raw: unknown; display: string }
+}
+
+/** One record's worth of pending changes, keyed by game_id/granblue_id */
+export interface CollectionUpdate {
+  game_id?: string
+  granblue_id: string
+  changes: CollectionChangeField[]
+}
+
+/** Response from checkCollectionUpdates / checkCharacterStatsUpdates */
+export interface CheckUpdatesResponse {
+  updates?: CollectionUpdate[]
+  error?: string
+}
+
 /** Response from previewSyncDeletions */
 export interface PreviewSyncDeletionsResponse {
   willDelete?: unknown[]
@@ -107,6 +130,19 @@ export interface RaidGroup {
 /** Response from fetchRaidGroups */
 export interface FetchRaidGroupsResponse {
   data?: RaidGroup[]
+  error?: string
+}
+
+/** A weapon's element-variant ID map (element index → game variant ID) */
+export interface ElementVariantEntry {
+  id?: string
+  granblue_id: string
+  element_variant_ids: Record<string, string>
+}
+
+/** Response from fetchElementVariants */
+export interface FetchElementVariantsResponse {
+  data?: ElementVariantEntry[]
   error?: string
 }
 


### PR DESCRIPTION
## Summary

Split the existing "Already in your collection" section into **Updates available** (pre-checked, expanded) and **Up to date** (unchecked, collapsed) so the save button actually updates records that have changed in-game instead of skipping them. Hover an updated item to see the exact field-level diff.

Covers weapons, characters, summons in the standard collection flow and the separate character-stats flow (rings/earrings/perpetuity/awakening).

Also lands an image fallback for Ultima/Atma/CCW/Superlative weapons whose per-element variant thumbnails 404 — the fallback resolves to the base granblue_id thumbnail via the new cached `/weapons/element_variants` map.

Depends on https://github.com/jedmund/hensei-api/pull/400.

## Test plan

- [x] `pnpm build` clean
- [ ] Load extension, open a weapon/character/summon collection view where at least one owned item has a known state change (mutated in DB via Rails console) — confirm "Updates available" section renders, default-expanded, pre-checked
- [ ] Hover a pending-update item — tooltip shows the field deltas matching the mutation
- [ ] "Up to date" section renders for the remainder, collapsed, unchecked
- [ ] Click Save → backend reports those items in `updated`, not `skipped`
- [ ] Character stats view with a mutated ring → tooltip shows the ring diff
- [ ] Genuinely unchanged items stay in "Up to date" and aren't pre-checked
- [ ] Ultima/Atma weapon with a variant ID whose thumbnail doesn't exist → fallback base thumbnail renders