### PR TITLE
fix oversized thumbnails in updates section

### DIFF
--- a/src/components/detail/items/ItemGrid.svelte
+++ b/src/components/detail/items/ItemGrid.svelte
@@ -140,26 +140,28 @@
         {/if}
       {/if}
       {#if pendingUpdate}
-        <RichTooltip>
-          {#snippet content()}
-            <div class="update-tooltip">
-              <div class="update-tooltip-title">{m.section_has_updates()}</div>
-              {#each pendingUpdate.changes as change}
-                <div class="update-tooltip-row">
-                  <span class="update-tooltip-label">{change.label}</span>
-                  <span class="update-tooltip-values">
-                    {change.before.display || '—'} → {change.after.display || '—'}
-                  </span>
-                </div>
-              {/each}
-            </div>
-          {/snippet}
-          <img
-            src={getItemImageUrl(dataType, item, simplePortraits)}
-            alt=""
-            onerror={(e) => handleImageError(originalIndex, e)}
-          />
-        </RichTooltip>
+        <div class="update-trigger">
+          <RichTooltip>
+            {#snippet content()}
+              <div class="update-tooltip">
+                <div class="update-tooltip-title">{m.section_has_updates()}</div>
+                {#each pendingUpdate.changes as change}
+                  <div class="update-tooltip-row">
+                    <span class="update-tooltip-label">{change.label}</span>
+                    <span class="update-tooltip-values">
+                      {change.before.display || '—'} → {change.after.display || '—'}
+                    </span>
+                  </div>
+                {/each}
+              </div>
+            {/snippet}
+            <img
+              src={getItemImageUrl(dataType, item, simplePortraits)}
+              alt=""
+              onerror={(e) => handleImageError(originalIndex, e)}
+            />
+          </RichTooltip>
+        </div>
         <span class="update-indicator" aria-hidden="true"></span>
       {:else}
         <img

--- a/src/entrypoints/sidepanel/styles/_detail.scss
+++ b/src/entrypoints/sidepanel/styles/_detail.scss
@@ -394,7 +394,20 @@ body.light #playlistCreateSubmit {
   background: var(--color-bg);
   container-type: inline-size;
 
-  > img {
+  > img,
+  > .update-trigger {
+    width: 100%;
+    height: auto;
+    display: block;
+    border-radius: layout.$item-corner;
+  }
+
+  > .update-trigger > span {
+    display: block;
+    width: 100%;
+  }
+
+  > .update-trigger img {
     width: 100%;
     height: auto;
     display: block;
@@ -410,6 +423,7 @@ body.light #playlistCreateSubmit {
     position: relative;
 
     > img,
+    > .update-trigger,
     > .weapon-modifiers {
       opacity: 0.35;
     }


### PR DESCRIPTION
## Summary

Thumbnails in the new "Updates available" section rendered at their intrinsic dimensions (huge) because wrapping the `<img>` in `<RichTooltip>` inserted a `<span>` between `.grid-item` and the image — breaking the `.grid-item > img` direct-child selector that sized the image to fit the grid cell.

Wraps the tooltipped image in a `.update-trigger` div and widens the sizing selectors to cover both the tooltipped and non-tooltipped path.

## Test plan

- [x] `pnpm build` clean
- [ ] Load extension, open a weapon collection view with at least one Ultima/Atma/CCW weapon that has a pending update
- [ ] Confirm thumbnails in the "Updates available" section render at the same size as the "Will import" section
- [ ] Hover an updated thumbnail — tooltip still appears with the field deltas