### PR TITLE
fix Database canonical-import click handler

### DIFF
--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -1417,6 +1417,9 @@ function resolveEndpoint(dataType: string): string | null {
   if (ENDPOINT_MAP[dataType]) return ENDPOINT_MAP[dataType]!
   if (dataType.startsWith('stash_weapon')) return 'weapons'
   if (dataType.startsWith('stash_summon')) return 'summons'
+  if (dataType.startsWith('detail_weapon')) return 'weapons'
+  if (dataType.startsWith('detail_summon')) return 'summons'
+  if (dataType.startsWith('detail_npc')) return 'characters'
   return null
 }
 


### PR DESCRIPTION
## Summary

Clicking Import in the Database detail view showed "Import failed" with no console log and no network call.

Root cause: `cacheDetailItem` stores the item under an `actualDataType` of `detail_weapon_<granblueId>` (e.g. `detail_weapon_1040020000`). `resolveEndpoint` had exact-match entries in `ENDPOINT_MAP` for `detail_weapon` / `detail_summon` / `detail_npc` and a prefix fallback for `stash_*`, but no prefix fallback for `detail_*`. The suffixed dataType never matched, so `uploadDetailData` early-returned `{ error: 'Unknown data type: ...' }` before hitting the network — only surfacing the generic "Import failed" toast.

Fix mirrors the existing `stash_*` handling.

Depends on https://github.com/jedmund/hensei-api/pull/402 for editors to actually succeed at the import (without it they'll hit `401 Unauthorized` from `ImportController#ensure_admin_role`).

## Test plan

- [x] `pnpm build` clean
- [ ] Editor-role user opens Database → weapon detail → Import → observe a POST to `/api/v1/import/weapons` and a success toast