### PR TITLE
Support Mobage Granblue domain

### DIFF
--- a/src/lib/debugger.ts
+++ b/src/lib/debugger.ts
@@ -11,7 +11,11 @@
 // ENDPOINT PATTERNS TO INTERCEPT
 // ==========================================
 
-const GBF_DOMAINS = ['game.granbluefantasy.jp', 'steam.granbluefantasy.com']
+const GBF_DOMAINS = [
+  'game.granbluefantasy.jp',
+  'gbf.game.mbga.jp',
+  'steam.granbluefantasy.com'
+]
 
 const INTERCEPT_PATTERNS = [
   '/party/deck',

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
     permissions: ['storage', 'debugger', 'tabs', 'sidePanel', 'cookies'],
     host_permissions: [
       'https://game.granbluefantasy.jp/*',
+      'https://gbf.game.mbga.jp/*',
       'https://granblue.team/*',
       'https://api.granblue.team/*',
       'https://next-api.granblue.team/*'


### PR DESCRIPTION
## Summary
- grant host access to `gbf.game.mbga.jp`
- recognize Mobage Granblue tabs for debugger attachment

## Testing
- `pnpm lint`
- `pnpm build`